### PR TITLE
[wasm] Return `FrameSet` on render 

### DIFF
--- a/compositor_web/example/index.html
+++ b/compositor_web/example/index.html
@@ -12,7 +12,7 @@
     <canvas id="headless-canvas" style="display:none" width="1280" height="1280"></canvas>
 
     <script type="module">
-        import init, {createRenderer, InputFrameSet} from "./pkg/compositor_web.js";
+        import init, {create_renderer, FrameSet} from "./pkg/compositor_web.js";
 
         const IMAGE1_URL = "https://media.tenor.com/eFPFHSN4rJ8AAAAM/example.gif";
         const IMAGE2_URL = "https://compositor.live/img/logo-dark.svg";
@@ -39,7 +39,7 @@
 
         function startRendering(imageData) {
             init().then(async () => {
-                const renderer = await createRenderer({
+                const renderer = await create_renderer({
                     framerate: {
                         num: 30,
                         den: 1
@@ -122,15 +122,15 @@
                         width: imageData.width,
                         height: imageData.height
                     },
-                    format: "rgbaBytes",
+                    format: "RGBA_BYTES",
                     data: imageData.data,
                 });
 
                 for (let i = 0; i < 100; i++) {
-                    const frame_set = new InputFrameSet(100 * i, inputs);
+                    const frame_set = new FrameSet(100 * i, inputs);
                     const outputs = renderer.render(frame_set);
-                    const output = outputs.get("output");
-                    ctx.putImageData(output, 0, 0);
+                    const output = outputs.frames.get("output");
+                    ctx.putImageData(new ImageData(output.data, output.resolution.width, output.resolution.height), 0, 0);
                     await sleep(10);
                 }
             });

--- a/compositor_web/src/wasm.rs
+++ b/compositor_web/src/wasm.rs
@@ -28,7 +28,7 @@ pub fn start() -> Result<(), JsValue> {
     Ok(())
 }
 
-#[wasm_bindgen(js_name = createRenderer)]
+#[wasm_bindgen]
 pub async fn create_renderer(options: JsValue) -> Result<LiveCompositorRenderer, JsValue> {
     let (device, queue) = create_wgpu_context().await?;
     let mut options: compositor_render::RendererOptions =
@@ -55,7 +55,7 @@ pub struct LiveCompositorRenderer {
 
 #[wasm_bindgen]
 impl LiveCompositorRenderer {
-    pub fn render(&mut self, input: types::InputFrameSet) -> Result<js_sys::Map, JsValue> {
+    pub fn render(&mut self, input: types::FrameSet) -> Result<types::FrameSet, JsValue> {
         let (device, queue) = self.renderer.wgpu_ctx();
         let frame_set = self.input_uploader.upload(&device, &queue, input)?;
 

--- a/compositor_web/src/wasm/input_uploader.rs
+++ b/compositor_web/src/wasm/input_uploader.rs
@@ -3,10 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use compositor_render::{Frame, FrameData, FrameSet, InputId};
 use wasm_bindgen::JsValue;
 
-use super::{
-    types::{FrameFormat, InputFrame, InputFrameSet},
-    wgpu::pad_to_256,
-};
+use super::{types, wgpu::pad_to_256};
 
 #[derive(Default)]
 pub struct InputUploader {
@@ -18,16 +15,16 @@ impl InputUploader {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        input: InputFrameSet,
+        input: types::FrameSet,
     ) -> Result<FrameSet<InputId>, JsValue> {
         let pts = Duration::from_millis(input.pts_ms as u64);
         let mut frames = HashMap::new();
         for frame in input.frames.entries() {
-            let frame: InputFrame = frame?.try_into()?;
+            let frame: types::Frame = frame?.try_into()?;
             self.upload_input_frame(device, queue, &frame);
 
             let data = match frame.format {
-                FrameFormat::RgbaBytes => FrameData::Rgba8UnormWgpuTexture(
+                types::FrameFormat::RgbaBytes => FrameData::Rgba8UnormWgpuTexture(
                     self.textures.get(&frame.id).unwrap().texture.clone(),
                 ),
             };
@@ -53,10 +50,10 @@ impl InputUploader {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        frame: &InputFrame,
+        frame: &types::Frame,
     ) {
         match frame.format {
-            FrameFormat::RgbaBytes => {
+            types::FrameFormat::RgbaBytes => {
                 let size = wgpu::Extent3d {
                     width: frame.resolution.width as u32,
                     height: frame.resolution.height as u32,
@@ -84,7 +81,7 @@ impl InputUploader {
         }
     }
 
-    fn create_texture(device: &wgpu::Device, frame: &InputFrame) -> Texture {
+    fn create_texture(device: &wgpu::Device, frame: &types::Frame) -> Texture {
         let size = wgpu::Extent3d {
             width: frame.resolution.width as u32,
             height: frame.resolution.height as u32,

--- a/compositor_web/src/wasm/output_downloader.rs
+++ b/compositor_web/src/wasm/output_downloader.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
-use compositor_render::{FrameData, FrameSet, OutputId, Resolution};
+use compositor_api::types as api;
+use compositor_render::{Frame, FrameData, FrameSet, OutputId, Resolution};
+use js_sys::Object;
 use tracing::error;
 use wasm_bindgen::JsValue;
-use web_sys::ImageData;
 
-use super::{types::to_js_error, wgpu::pad_to_256};
+use super::{
+    types::{self, to_js_error},
+    wgpu::pad_to_256,
+};
 
 #[derive(Default)]
 pub struct OutputDownloader {
@@ -18,7 +22,7 @@ impl OutputDownloader {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         outputs: FrameSet<OutputId>,
-    ) -> Result<js_sys::Map, JsValue> {
+    ) -> Result<types::FrameSet, JsValue> {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
         for (id, frame) in outputs.frames.iter() {
@@ -53,26 +57,41 @@ impl OutputDownloader {
         let output_data = js_sys::Map::new();
         for (id, map_complete_receiver) in pending_downloads {
             map_complete_receiver.recv().unwrap().map_err(to_js_error)?;
-            let resolution = outputs.frames.get(&id).unwrap().resolution;
+            let frame = outputs.frames.get(&id).unwrap();
             let buffer = self.buffers.get(&id).unwrap();
-            {
-                let buffer_view = buffer.slice(..).get_mapped_range();
-                let data = ImageData::new_with_u8_clamped_array_and_sh(
-                    wasm_bindgen::Clamped(&buffer_view),
-                    resolution.width as u32,
-                    resolution.height as u32,
-                )?;
-                output_data.set(&id.to_string().into(), &data.into());
-            }
+            let frame_object = Self::create_frame_object(frame, buffer)?;
+            output_data.set(&id.to_string().into(), &frame_object);
 
             buffer.unmap();
         }
 
-        Ok(output_data)
+        Ok(types::FrameSet {
+            pts_ms: outputs.pts.as_millis() as f64,
+            frames: output_data,
+        })
     }
 
     pub fn remove_output(&mut self, output_id: &OutputId) {
         self.buffers.remove(output_id);
+    }
+
+    fn create_frame_object(frame: &Frame, buffer: &wgpu::Buffer) -> Result<Object, JsValue> {
+        let buffer_view = buffer.slice(..).get_mapped_range();
+        let resolution = api::Resolution {
+            width: frame.resolution.width,
+            height: frame.resolution.height,
+        };
+        let format = match frame.data {
+            FrameData::Rgba8UnormWgpuTexture(_) => types::FrameFormat::RgbaBytes,
+            _ => return Err(JsValue::from_str("Unsupported output frame format")),
+        };
+
+        let frame = Object::new();
+        frame.set("resolution", serde_wasm_bindgen::to_value(&resolution)?)?;
+        frame.set("format", serde_wasm_bindgen::to_value(&format)?)?;
+        frame.set("data", wasm_bindgen::Clamped(buffer_view.to_vec()))?;
+
+        return Ok(frame);
     }
 
     fn create_buffer(device: &wgpu::Device, resolution: Resolution) -> wgpu::Buffer {
@@ -108,5 +127,16 @@ impl OutputDownloader {
             },
             size,
         );
+    }
+}
+
+trait ObjectExt {
+    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue>;
+}
+
+impl ObjectExt for Object {
+    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue> {
+        js_sys::Reflect::set(self, &JsValue::from_str(key), &value.into())?;
+        Ok(())
     }
 }

--- a/compositor_web/src/wasm/types.rs
+++ b/compositor_web/src/wasm/types.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use compositor_render::{web_renderer::WebRendererInitOptions, InputId, Resolution};
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[derive(Debug, Deserialize)]
@@ -17,7 +17,7 @@ pub struct Framerate {
 }
 
 #[wasm_bindgen]
-pub struct InputFrameSet {
+pub struct FrameSet {
     pub pts_ms: f64,
 
     #[wasm_bindgen(skip)]
@@ -25,7 +25,7 @@ pub struct InputFrameSet {
 }
 
 #[wasm_bindgen]
-impl InputFrameSet {
+impl FrameSet {
     #[wasm_bindgen(constructor)]
     pub fn new(pts_ms: f64, frames: js_sys::Map) -> Self {
         Self { pts_ms, frames }
@@ -42,7 +42,7 @@ impl InputFrameSet {
     }
 }
 
-pub struct InputFrame {
+pub struct Frame {
     pub id: InputId,
     pub resolution: Resolution,
     pub format: FrameFormat,
@@ -50,8 +50,8 @@ pub struct InputFrame {
 }
 
 #[wasm_bindgen]
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FrameFormat {
     RgbaBytes,
 }
@@ -89,7 +89,7 @@ impl From<Framerate> for compositor_render::Framerate {
     }
 }
 
-impl TryFrom<JsValue> for InputFrame {
+impl TryFrom<JsValue> for Frame {
     type Error = JsValue;
 
     fn try_from(entry: JsValue) -> Result<Self, Self::Error> {


### PR DESCRIPTION
 Currently wasm's `render` returns a map `OutputId => Bytes`. But, `render` method from `compositor_render` returns `FrameSet` which contains more additional information. In this PR I changed the wasm implimentation to also return `FrameSet`