### PR TITLE
fix event handler: removing disconnected subscribers

### DIFF
--- a/compositor_render/src/event_handler.rs
+++ b/compositor_render/src/event_handler.rs
@@ -60,9 +60,9 @@ impl Emitter {
             .enumerate()
             .filter_map(|(index, sender)| {
                 if disconnected.contains(&index) {
-                    Some(sender)
-                } else {
                     None
+                } else {
+                    Some(sender)
                 }
             })
             .collect()


### PR DESCRIPTION
There is a bug in the event_handler: the `Emitter` removes active subscribers instead of dead ones.

All the actually active subscribers will get an error when asking a message as their Sender was dropped.