### PR TITLE
[wasm] Fix bundler config

### DIFF
--- a/build_tools/nix/flake.nix
+++ b/build_tools/nix/flake.nix
@@ -52,13 +52,14 @@
             gst_all_1.gst-plugins-ugly
             gst_all_1.gst-libav
 
-            nodejs_18
+            nodejs_20
             rustfmt
             clippy
             cargo-watch
             cargo-nextest
             rust-analyzer
             clang-tools
+            llvmPackages.bintools
           ];
         in
         {

--- a/ts/@live-compositor/browser-render/package.json
+++ b/ts/@live-compositor/browser-render/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "watch": "tsc --watch --preserveWatchOutput",
+    "watch": "rollup -w --no-watch.clearScreen -c",
     "build-wasm": "node ./scripts/buildWasm.mjs",
     "build": "rollup -c",
     "clean": "rimraf dist"

--- a/ts/@live-compositor/browser-render/rollup.config.mjs
+++ b/ts/@live-compositor/browser-render/rollup.config.mjs
@@ -7,24 +7,27 @@ export default [
     input: 'src/index.ts',
     output: {
       file: 'dist/index.js',
-      format: 'es'
+      format: 'es',
     },
     plugins: [
       typescript(),
       copy({
         targets: [
-          { src: 'src/generated', dest: 'dist' },
-          { src: 'src/generated/compositor_web_bg.wasm', dest: 'dist', rename: 'live-compositor.wasm' }
-        ]
-      })
-    ]
+          {
+            src: 'src/generated/compositor_web_bg.wasm',
+            dest: 'dist',
+            rename: 'live-compositor.wasm',
+          },
+        ],
+      }),
+    ],
   },
   {
-    input: 'dist/index.d.ts',
+    input: './src/index.ts',
     output: {
       file: 'dist/index.d.ts',
       format: 'es',
     },
-    plugins: [dts()]
-  }
+    plugins: [dts()],
+  },
 ];

--- a/ts/@live-compositor/browser-render/scripts/buildWasm.mjs
+++ b/ts/@live-compositor/browser-render/scripts/buildWasm.mjs
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import { spawn as nodeSpawn } from 'child_process';
+import path from 'node:path';
+import { spawn as nodeSpawn } from 'node:child_process';
 
 async function build() {
   const dirName = import.meta.dirname;

--- a/ts/@live-compositor/browser-render/tsconfig.json
+++ b/ts/@live-compositor/browser-render/tsconfig.json
@@ -4,9 +4,11 @@
     "outDir": "dist",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "target": "ESNext"
+    "target": "ESNext",
+    "noEmit": true,
+    "declaration": false
   },
-  "exclude": [
-    "example"
+  "include": [
+    "./src/**/*"
   ]
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -6,6 +6,7 @@
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint -- --fix",
     "build": "lerna run build --concurrency=1",
+    "build-sdk": "lerna run build --concurrency 1 --scope @live-compositor/core --scope @live-compositor/node --scope live-compositor --scope examples",
     "typecheck": "lerna run typecheck",
     "clean": "lerna run clean",
     "watch": "lerna run --parallel --stream watch --private",


### PR DESCRIPTION
- In the dist directory index.ts is generated for just index.d.ts, the section that should generate d.ts did not work. Type files were showing up only because `declaration: true`
- Node 20 is required to build wasm
- watch command should build with rollup not tsc
- Add `build-sdk` command to avoid building wasm when it is not needed
