### PR TITLE
Support pipeline shutdown

### DIFF
--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -6,7 +6,10 @@ mod video_queue;
 use std::{
     collections::HashMap,
     fmt::Debug,
-    sync::{atomic::{AtomicBool, Ordering}, Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::{Duration, Instant},
 };
 


### PR DESCRIPTION
- Stop queue when pipeline is dropped
- Do not hold to Arc<Pipeline> in render threads

Tested by creating pipeline and dropping it in the loop and observing memory usage