### PR TITLE
[wasm] Add YUV input

### DIFF
--- a/compositor_web/src/wasm/input_uploader.rs
+++ b/compositor_web/src/wasm/input_uploader.rs
@@ -28,7 +28,9 @@ impl InputUploader {
                 types::FrameFormat::RgbaBytes => FrameData::Rgba8UnormWgpuTexture(
                     self.textures.get(&frame.id).unwrap().texture.clone(),
                 ),
-                types::FrameFormat::YuvBytes => FrameData::PlanarYuv420(Self::create_yuv_planes(&frame))
+                types::FrameFormat::YuvBytes => {
+                    FrameData::PlanarYuv420(Self::create_yuv_planes(&frame))
+                }
             };
 
             frames.insert(

--- a/compositor_web/src/wasm/types.rs
+++ b/compositor_web/src/wasm/types.rs
@@ -47,12 +47,14 @@ pub struct Frame {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FrameFormat {
     RgbaBytes,
+    YuvBytes,
 }
 
 impl From<FrameFormat> for compositor_render::OutputFrameFormat {
     fn from(value: FrameFormat) -> Self {
         match value {
             FrameFormat::RgbaBytes => compositor_render::OutputFrameFormat::RgbaWgpuTexture,
+            FrameFormat::YuvBytes => compositor_render::OutputFrameFormat::PlanarYuv420Bytes,
         }
     }
 }

--- a/ts/@live-compositor/browser-render/src/renderer.ts
+++ b/ts/@live-compositor/browser-render/src/renderer.ts
@@ -26,6 +26,7 @@ export type Frame = {
 
 export enum FrameFormat {
   RGBA_BYTES = 'RGBA_BYTES',
+  YUV_BYTES = 'YUV_BYTES',
 }
 
 export class Renderer {


### PR DESCRIPTION
Added YUV input format. Safari's implementation of `VideoDecoder` does not output RGBA but YUV420.

Closes: https://github.com/software-mansion/live-compositor/issues/746