### PR TITLE
[docs] Add example requests to API Reference

### DIFF
--- a/docs/pages/api/inputs/decklink.md
+++ b/docs/pages/api/inputs/decklink.md
@@ -1,5 +1,6 @@
 ---
 title: DeckLink
+hide_table_of_contents: true
 ---
 import Docs from "@site/pages/api/generated/renderer-DeckLink.md"
 

--- a/docs/pages/api/inputs/decklink.md
+++ b/docs/pages/api/inputs/decklink.md
@@ -17,16 +17,20 @@ To use DeckLink Input you must register it first. You can do it by sending a req
 
 <details>
     <summary>Example request</summary>
-    ```http
-    POST: /api/input/input_1/register
-    Content-Type: application/json
 
+    ```http
+    POST: /api/input/:input_id/register
+    Content-Type: application/json
+    ```
+
+    ```js
     {
-    "subdevice_index": 0,
-    "display_name": "DeckLink Quad HDMI Recorder (3)",
-    "persistent_id": "ffffffff"
-    "enable_audio": false,
-    "required": true,
+      "type": "decklink",
+      "subdevice_index": 0,
+      "display_name": "DeckLink Quad HDMI Recorder (3)",
+      "persistent_id": "ffffffff",
+      "enable_audio": false,
+      "required": true,
     }
     ```
 </details>

--- a/docs/pages/api/inputs/decklink.md
+++ b/docs/pages/api/inputs/decklink.md
@@ -14,7 +14,7 @@ An input type that allows consuming streams from Blackmagic DeckLink cards.
 
 ### Usage
 
-To use DeckLink Input you must register it first. You can do it by sending a request like this:
+To use DeckLink input you must register it first. You can do it by sending a request like this:
 
 <details>
     <summary>Example request</summary>
@@ -27,11 +27,7 @@ To use DeckLink Input you must register it first. You can do it by sending a req
     ```js
     {
       "type": "decklink",
-      "subdevice_index": 0,
-      "display_name": "DeckLink Quad HDMI Recorder (3)",
-      "persistent_id": "ffffffff",
-      "enable_audio": false,
-      "required": true,
+      "display_name": "DeckLink Quad HDMI Recorder (3)"
     }
     ```
 </details>

--- a/docs/pages/api/inputs/decklink.md
+++ b/docs/pages/api/inputs/decklink.md
@@ -11,4 +11,26 @@ import Docs from "@site/pages/api/generated/renderer-DeckLink.md"
 
 An input type that allows consuming streams from Blackmagic DeckLink cards.
 
+### Usage
+
+To use DeckLink Input you must register it first. You can do it by sending a request like this:
+
+<details>
+    <summary>Example request</summary>
+    ```http
+    POST: /api/input/input_1/register
+    Content-Type: application/json
+
+    {
+    "subdevice_index": 0,
+    "display_name": "DeckLink Quad HDMI Recorder (3)",
+    "persistent_id": "ffffffff"
+    "enable_audio": false,
+    "required": true,
+    }
+    ```
+</details>
+
+See [HTTP Routes](../routes.md#outputs-configuration) documentation to learn more about managing inputs.
+
 <Docs />

--- a/docs/pages/api/inputs/mp4.md
+++ b/docs/pages/api/inputs/mp4.md
@@ -8,4 +8,25 @@ This input type supports mp4 video tracks encoded with h264 and audio tracks enc
 
 If the file contains multiple video or audio tracks, the first audio track and the first video track will be used and the other ones will be ignored.
 
+### Usage
+
+To use MP4 Input you must register it first. You can do it by sending a request like this:
+
+<details>
+    <summary>Example request</summary>
+    ```http
+    POST: /api/input/input_1/register
+    Content-Type: application/json
+
+    {
+    "url": "https://url.to.file.mp4",
+    "loop": true,
+    "required": true,
+    "offset_ms": 128
+    }
+    ```
+</details>
+
+See [HTTP Routes](../routes.md#outputs-configuration) documentation to learn more about managing inputs.
+
 <Docs />

--- a/docs/pages/api/inputs/mp4.md
+++ b/docs/pages/api/inputs/mp4.md
@@ -28,10 +28,7 @@ To use MP4 Input you must register it first. You can do it by sending a request 
     ```js
     {
       "type": "mp4"
-      "url": "https://url.to.file.mp4",
-      "loop": true,
-      "required": true,
-      "offset_ms": 128
+      "url": "https://url.to.file.mp4"
     }
     ```
 </details>

--- a/docs/pages/api/inputs/mp4.md
+++ b/docs/pages/api/inputs/mp4.md
@@ -1,3 +1,8 @@
+---
+title: MP4
+hide_table_of_contents: true
+---
+
 import Docs from "@site/pages/api/generated/renderer-Mp4Input.md"
 
 # MP4

--- a/docs/pages/api/inputs/mp4.md
+++ b/docs/pages/api/inputs/mp4.md
@@ -14,15 +14,19 @@ To use MP4 Input you must register it first. You can do it by sending a request 
 
 <details>
     <summary>Example request</summary>
-    ```http
-    POST: /api/input/input_1/register
-    Content-Type: application/json
 
+    ```http
+    POST: /api/input/:input_id/register
+    Content-Type: application/json
+    ```
+
+    ```js
     {
-    "url": "https://url.to.file.mp4",
-    "loop": true,
-    "required": true,
-    "offset_ms": 128
+      "type": "mp4"
+      "url": "https://url.to.file.mp4",
+      "loop": true,
+      "required": true,
+      "offset_ms": 128
     }
     ```
 </details>

--- a/docs/pages/api/inputs/rtp.md
+++ b/docs/pages/api/inputs/rtp.md
@@ -30,9 +30,7 @@ To use RTP Input you must register it first. You can do it by sending a request 
       },
       "audio": {
         "decoder": "opus"
-      },
-      "required": true,
-      "offset_ms": 64
+      }
     }
     ```
 </details>

--- a/docs/pages/api/inputs/rtp.md
+++ b/docs/pages/api/inputs/rtp.md
@@ -1,3 +1,8 @@
+---
+title: RTP
+hide_table_of_contents: true
+---
+
 import Docs from "@site/pages/api/generated/renderer-RtpInputStream.md"
 
 # RTP
@@ -17,17 +22,17 @@ To use RTP Input you must register it first. You can do it by sending a request 
 
     ```js
     {
-    "type": "rtp_stream",
-    "transport_protocol": "tcp_server",
-    "port": 9001,
-    "video": {
-      "decoder": "ffmpeg_h264"
-    },
-    "audio": {
-      "decoder": "opus"
-    },
-    "required": true,
-    "offset_ms": 64
+      "type": "rtp_stream",
+      "transport_protocol": "tcp_server",
+      "port": 9001,
+      "video": {
+        "decoder": "ffmpeg_h264"
+      },
+      "audio": {
+        "decoder": "opus"
+      },
+      "required": true,
+      "offset_ms": 64
     }
     ```
 </details>

--- a/docs/pages/api/inputs/rtp.md
+++ b/docs/pages/api/inputs/rtp.md
@@ -3,4 +3,33 @@ import Docs from "@site/pages/api/generated/renderer-RtpInputStream.md"
 # RTP
 An input type that allows streaming video and audio to the compositor over RTP.
 
+### Usage
+
+To use RTP Input you must register it first. You can do it by sending a request like this:
+
+<details>
+    <summary>Example request</summary>
+    ```http
+    POST: /api/input/input_1/register
+    Content-Type: application/json
+
+    {
+    "type": "rtp_stream",
+    "transport_protocol": "tcp_server",
+    "port": 9001,
+    "video": {
+      "decoder": "ffmpeg_h264"
+    },
+    "audio": {
+      "decoder": "opus"
+    },
+    "required": true,
+    "offset_ms": 64
+    }
+    ```
+</details>
+
+See [HTTP Routes](../routes.md#outputs-configuration) documentation to learn more about managing inputs.
+You can also check out [our guide](../../guides/deliver-input.md) to learn how to deliver streams after registering them.
+
 <Docs />

--- a/docs/pages/api/inputs/rtp.md
+++ b/docs/pages/api/inputs/rtp.md
@@ -9,10 +9,13 @@ To use RTP Input you must register it first. You can do it by sending a request 
 
 <details>
     <summary>Example request</summary>
-    ```http
-    POST: /api/input/input_1/register
-    Content-Type: application/json
 
+    ```http
+    POST: /api/input/:input_id/register
+    Content-Type: application/json
+    ```
+
+    ```js
     {
     "type": "rtp_stream",
     "transport_protocol": "tcp_server",

--- a/docs/pages/api/outputs/mp4.md
+++ b/docs/pages/api/outputs/mp4.md
@@ -1,6 +1,8 @@
 ---
 title: MP4
+hide_table_of_contents: true
 ---
+
 import Docs from "@site/pages/api/generated/output-Mp4Output.md"
 
 <span class="badge badge--primary">Added in v0.3.0</span>

--- a/docs/pages/api/outputs/mp4.md
+++ b/docs/pages/api/outputs/mp4.md
@@ -11,4 +11,50 @@ import Docs from "@site/pages/api/generated/output-Mp4Output.md"
 
 An output type that allows saving video and audio from the compositor to MP4 file.
 
+### Usage
+
+To use MP4 Output you need to register it first.
+
+<details>
+    <summary> Example register requests </summary>
+    ```http
+    POST: /api/output/:output_id/register
+    Content-Type: application/json
+
+    {
+      "type": "mp4",
+      "path": "/path/to/file.mp4",
+      "video": {
+        "resolution": { "width": 1280, "height": 720 },
+        "encoder": {
+          "type": "ffmpeg_h264",
+          "preset": "ultrafast",
+          "ffmpeg_options": { "crf": 32 }
+        },
+        "initial": {
+          "root": {
+            "type": "view",
+            "background_color_rgba": "#4d4d4dff"
+          }
+        }
+      },
+      "audio": {
+        "mixing_strategy": "sum_scale",
+        "send_eos_when": {
+          "any_of": [ "input1" ]
+        },
+        "encoder": {
+          "type": "aac",
+          "channels": "stereo"
+        },
+        "initial": {
+          "inputs": [{ "input_id": "input_1", "volume": 0.64 }]
+        }
+      }
+    }
+    ```
+</details>
+
+See [HTTP Routes](../routes.md#outputs-configuration) documentation to learn more about managing outputs.
+
 <Docs />

--- a/docs/pages/api/outputs/mp4.md
+++ b/docs/pages/api/outputs/mp4.md
@@ -17,10 +17,13 @@ To use MP4 Output you need to register it first.
 
 <details>
     <summary> Example register requests </summary>
+
     ```http
     POST: /api/output/:output_id/register
     Content-Type: application/json
+    ```
 
+    ```js
     {
       "type": "mp4",
       "path": "/path/to/file.mp4",
@@ -29,7 +32,7 @@ To use MP4 Output you need to register it first.
         "encoder": {
           "type": "ffmpeg_h264",
           "preset": "ultrafast",
-          "ffmpeg_options": { "crf": 32 }
+          "ffmpeg_options": { "crf": "32" }
         },
         "initial": {
           "root": {

--- a/docs/pages/api/outputs/mp4.md
+++ b/docs/pages/api/outputs/mp4.md
@@ -33,8 +33,7 @@ To use MP4 Output you need to register it first.
         "resolution": { "width": 1280, "height": 720 },
         "encoder": {
           "type": "ffmpeg_h264",
-          "preset": "ultrafast",
-          "ffmpeg_options": { "crf": "32" }
+          "preset": "ultrafast"
         },
         "initial": {
           "root": {
@@ -44,10 +43,6 @@ To use MP4 Output you need to register it first.
         }
       },
       "audio": {
-        "mixing_strategy": "sum_scale",
-        "send_eos_when": {
-          "any_of": [ "input1" ]
-        },
         "encoder": {
           "type": "aac",
           "channels": "stereo"

--- a/docs/pages/api/outputs/rtp.md
+++ b/docs/pages/api/outputs/rtp.md
@@ -10,10 +10,13 @@ To use RTP Output you must register it first. You can do it by sending a request
 
 <details>
     <summary>Example request</summary>
-    ```http
-    POST: /api/output/output_1/register
-    Content-Type: application/json
 
+    ```http
+    POST: /api/output/:output_id/register
+    Content-Type: application/json
+    ```
+
+    ```js
     {
       "type": "rtp_stream",
       "transport_protocol": "tcp_server",

--- a/docs/pages/api/outputs/rtp.md
+++ b/docs/pages/api/outputs/rtp.md
@@ -4,4 +4,47 @@ import Docs from "@site/pages/api/generated/output-RtpOutputStream.md"
 
 An output type that allows streaming video and audio from the compositor over RTP.
 
+## Usage
+
+To use RTP Output you must register it first. You can do it by sending a request like this:
+
+<details>
+    <summary>Example request</summary>
+    ```http
+    POST: /api/output/output_1/register
+    Content-Type: application/json
+
+    {
+      "type": "rtp_stream",
+      "transport_protocol": "tcp_server",
+      "port": 9003,
+      "video": {
+        "resolution": { "width": 1280, "height": 720 },
+        "encoder": {
+          "type": "ffmpeg_h264",
+          "preset": "ultrafast",
+        },
+        "initial": {
+          "root": {
+            "type": "view",
+            "background_color_rgba": "#4d4d4dff"
+          }
+        }
+      },
+      "audio": {
+        "encoder": {
+          "type": "opus",
+          "channels": "mono",
+        },
+        "initial": {
+          "inputs": [{ "input_id": "input_1" }]
+        }
+      }
+    }
+    ```
+</details>
+
+See [HTTP Routes](../routes.md#outputs-configuration) documentation to learn more about managing outputs.
+You can also check out [our guide](../../guides/receive-output.md) to learn how to receive streams after registering them.
+
 <Docs />

--- a/docs/pages/api/outputs/rtp.md
+++ b/docs/pages/api/outputs/rtp.md
@@ -1,3 +1,8 @@
+---
+title: RTP
+hide_table_of_contents: true
+---
+
 import Docs from "@site/pages/api/generated/output-RtpOutputStream.md"
 
 # RTP


### PR DESCRIPTION
PR for #752 

Added example requests to RTP/MP4/DeckLink pages to make going to HTTP Routes page not necessary.
Requests are split into two code blocks to make copying request json easier.

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/b2b3d4ca-d61a-4fa7-8f23-20f8b49e003a">

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/0aaecca8-d932-41b1-9ead-98dafd7abe70">
