### PR TITLE
Make encoder preset optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 🔧 Others
 
 - Automatically rename file under the output path for MP4 output if it already exists. ([#684](https://github.com/software-mansion/live-compositor/pull/684) by [@WojciechBarczynski](https://github.com/WojciechBarczynski))
+- Make `video.encoder.preset` optional in the output register. ([#782](https://github.com/software-mansion/live-compositor/pull/782) by [@WojciechBarczynski](https://github.com/WojciechBarczynski))
 
 ## [v0.3.0](https://github.com/software-mansion/live-compositor/releases/tag/v0.3.0)
 

--- a/compositor_api/src/types/from_register_output.rs
+++ b/compositor_api/src/types/from_register_output.rs
@@ -191,7 +191,7 @@ fn maybe_video_options(
             preset,
             ffmpeg_options,
         } => pipeline::encoder::VideoEncoderOptions::H264(ffmpeg_h264::Options {
-            preset: preset.into(),
+            preset: preset.unwrap_or(H264EncoderPreset::Fast).into(),
             resolution: options.resolution.into(),
             raw_options: ffmpeg_options.unwrap_or_default().into_iter().collect(),
         }),

--- a/compositor_api/src/types/register_output.rs
+++ b/compositor_api/src/types/register_output.rs
@@ -83,7 +83,7 @@ pub enum VideoEncoderOptions {
     #[serde(rename = "ffmpeg_h264")]
     FfmpegH264 {
         /// (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
-        preset: H264EncoderPreset,
+        preset: Option<H264EncoderPreset>,
 
         /// Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
         ffmpeg_options: Option<HashMap<String, String>>,

--- a/ts/live-compositor/src/types/registerOutput.ts
+++ b/ts/live-compositor/src/types/registerOutput.ts
@@ -78,7 +78,7 @@ export type RtpVideoEncoderOptions = {
   /**
    * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
    */
-  preset: Api.H264EncoderPreset;
+  preset?: Api.H264EncoderPreset;
   /**
    * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
    */
@@ -90,7 +90,7 @@ export type Mp4VideoEncoderOptions = {
   /**
    * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
    */
-  preset: Api.H264EncoderPreset;
+  preset?: Api.H264EncoderPreset;
   /**
    * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
    */

--- a/ts/live-compositor/src/types/registerOutput.ts
+++ b/ts/live-compositor/src/types/registerOutput.ts
@@ -78,7 +78,7 @@ export type RtpVideoEncoderOptions = {
   /**
    * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
    */
-  preset?: Api.H264EncoderPreset;
+  preset: Api.H264EncoderPreset;
   /**
    * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
    */
@@ -90,7 +90,7 @@ export type Mp4VideoEncoderOptions = {
   /**
    * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
    */
-  preset?: Api.H264EncoderPreset;
+  preset: Api.H264EncoderPreset;
   /**
    * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
    */


### PR DESCRIPTION
I don't have a strong option, but I noticed that the encoder field documentation was inconsistent with the implementation. We can make this field required and change docs instead. It's your call.