### PR TITLE
[docs] Rework getting started section + Add TypeScript

### DIFF
--- a/docs/pages/guides/basic-layouts.md
+++ b/docs/pages/guides/basic-layouts.md
@@ -27,6 +27,17 @@ After configuration you should see the following output:
 Update output to render a [`View`](../api/components/View.md) component with an [`InputStream`](../api/components/InputStream.md) as its child.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return (
+        <View backgroundColor="#4d4d4d">
+          <InputStream inputId="input_1" />
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update
@@ -76,6 +87,19 @@ The input stream in the example has a resolution `1920x1080` and it is rendered 
 Wrap an [`InputStream`](../api/components/InputStream.md) component with a [`Rescaler`](../api/components/Rescaler.md).
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update
@@ -137,6 +161,22 @@ The same effect (for single input) could be achieved by either:
 Add another [`InputStream`](../api/components/InputStream.md) wrapped with [`Rescaler`](../api/components/Rescaler.md).
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+          <Rescaler>
+            <InputStream inputId="input_2" />
+          </Rescaler>
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update
@@ -205,6 +245,22 @@ In an example below we can see that:
 Specify `width` and `height` of one of the `Rescaler` components and position it using `top`/`right` options in the corner.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+          <Rescaler width={320} height={180} top={20} right={20}>
+            <InputStream inputId="input_2" />
+          </Rescaler>
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update

--- a/docs/pages/guides/quick-start.md
+++ b/docs/pages/guides/quick-start.md
@@ -12,6 +12,16 @@ This guide will explain basic LiveCompositor setup.
 ### Start the compositor
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    import LiveCompositor from "@live-compositor/node"
+
+    async function start() {
+        const compositor = new LiveCompositor();
+        await compositor.init();
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     Start the compositor server. Check out [configuration page](../deployment/configuration.md) for available configuration options.
   </TabItem>
@@ -43,6 +53,21 @@ This guide will explain basic LiveCompositor setup.
 ### Register input stream `input_1`.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    await compositor.registerInput("input_1", {
+      type: "rtp_stream",
+      transportProtocol: "tcp_server",
+      port: 9001,
+      video: {
+        decoder: "ffmpeg_h264"
+      }
+    })
+    ```
+    After `registerInput` call is done you can establish the connection and start sending the stream. Check out [how to deliver input streams](./deliver-input.md) to learn more.
+
+    In this example we are using RTP over TCP, but it could be easily replaced by UDP.
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/input/input_1/register
@@ -88,6 +113,21 @@ This guide will explain basic LiveCompositor setup.
 ### Register input stream `input_2`.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    await compositor.registerInput("input_2", {
+      type: "rtp_stream",
+      transportProtocol: "tcp_server",
+      port: 9002,
+      video: {
+        decoder: "ffmpeg_h264"
+      }
+    })
+    ```
+    After `registerInput` call is done you can establish the connection and start sending the stream. Check out [how to deliver input streams](./deliver-input.md) to learn more.
+
+    In this example we are using RTP over TCP, but it could be easily replaced by UDP.
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/input/input_2/register
@@ -137,6 +177,41 @@ Configure it to:
 - produce silent audio
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return <View backgroundColor="#4d4d4d"/>
+    }
+
+    async function start() {
+      // init code from previous steps
+
+      await compositor.registerOutput("output_1", {
+        type: "rtp_stream",
+        transportProtocol: "tcp_server",
+        port: 9003,
+        video: {
+          resolution: { width: 1280, height: 720 },
+          encoder": {
+            type: "ffmpeg_h264",
+            preset: "ultrafast"
+          },
+          root: <App />
+        },
+        audio: {
+          encoder: {
+            type: "opus",
+            channels: "stereo"
+          },
+        }
+      })
+    }
+    ```
+    After `registerOutput` is done you can establish the connection and start listening for the stream. Check out [how to receive output streams](./receive-output.md) to learn more.
+
+    In this example we are using RTP over TCP, if you prefer to use UDP you need start listening on the specified
+    port before registering output to make sure you are not losing first frames.
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/register
@@ -170,8 +245,6 @@ Configure it to:
       }
     }
     ```
-    You can configure the output framerate and the sample rate using [`LIVE_COMPOSITOR_OUTPUT_FRAMERATE`](../deployment/configuration.md#live_compositor_output_framerate) and [`LIVE_COMPOSITOR_OUTPUT_SAMPLE_RATE`](../deployment/configuration.md#live_compositor_output_sample_rate) environment variables.
-
     After receiving the response you can establish the connection and start listening for the stream. Check out [how to receive output streams](./receive-output.md) to learn more.
 
     In this example we are using RTP over TCP, if you prefer to use UDP you need start listening on the specified port before sending register request to make sure you are not losing
@@ -235,6 +308,18 @@ Configure it to:
 - Mix audio from input streams `input_1` and `input_2`, where `input_1` volume is slightly lowered.  
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      return (
+        <Tiles backgroundColor="#4d4d4d">
+          <InputStream inputId="input_1" volume={0.9} />
+          <InputStream inputId="input_2" />
+        </Tiles>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update

--- a/docs/pages/guides/view-transition.md
+++ b/docs/pages/guides/view-transition.md
@@ -17,6 +17,26 @@ guide in the ["Configure inputs and output"](./quick-start.md#configure-inputs-a
 ### Transition that changes the `width` of an input stream
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      const [beforeTransition, setBeforeTransition] = useState(true);
+      useEffect(() => {
+        setTimeout(() => setBeforeTransition(false), 2000);
+      }, []);
+
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler
+            width={beforeTransition ? 480 : 1280}
+            transition={{ durationMs: 2000 }}>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     Set initial scene for the transition:
     ```http
@@ -139,6 +159,29 @@ components that are not a part of the transition, but their size and position st
 Add a second input stream wrapped with `Rescaler`, but without any transition options.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      const [beforeTransition, setBeforeTransition] = useState(true);
+      useEffect(() => {
+        setTimeout(() => setBeforeTransition(false), 2000);
+      }, []);
+
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler
+            width={beforeTransition ? 480 : 1280}
+            transition={{ durationMs: 2000 }}>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+          <Rescaler>
+            <InputStream inputId="input_2" />
+          </Rescaler>
+        </View>
+      )
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update
@@ -273,6 +316,30 @@ on the parent layout.
 Let's try the same example as in the first scenario with a single input, but instead, change the `Rescaler` component to be absolutely positioned in the second update.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      const [beforeTransition, setBeforeTransition] = useState(true);
+      useEffect(() => {
+        setTimeout(() => setBeforeTransition(false), 2000);
+      }, []);
+
+      return (
+        <View backgroundColor="#4d4d4d">
+          {beforeTransition ? (
+            <Rescaler width={480}>
+              <InputStream inputId="input_1" />
+            </Rescaler>
+          ) : (
+            <Rescaler width={1280} top={0} left={0} transition={{ durationMs: 2000 }} >
+              <InputStream inputId="input_1" />
+            </Rescaler>
+          )}
+        </View>
+      );
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update
@@ -390,6 +457,55 @@ All of the above examples use default linear interpolation, but there are also a
 modes available.
 
 <Tabs queryString="lang">
+  <TabItem value="react" label="React">
+    ```tsx
+    function App() {
+      const [beforeTransition, setBeforeTransition] = useState(true);
+      useEffect(() => {
+        setTimeout(() => setBeforeTransition(false), 2000);
+      }, []);
+
+      const top = beforeTransition ? 0 : 540;
+
+      return (
+        <View backgroundColor="#4d4d4d">
+          <Rescaler
+            width={320} height={180} top={top} left={0}
+            transition={{ durationMs: 2000 }}>
+            <InputStream inputId="input_1" />
+          </Rescaler>
+          <Rescaler
+            width={320} height={180} top={top} left={320}
+            transition={{ durationMs: 2000, easingFunction: 'bounce' }}>
+            <InputStream inputId="input_2" />
+          </Rescaler>
+          <Rescaler
+            width={320} height={180} top={top} left={640}
+            transition={{
+              durationMs: 2000,
+              easingFunction: {
+                functionName: 'cubic_bezier',
+                points: [0.65, 0, 0.35, 1],
+              },
+            }}>
+            <InputStream inputId="input_3" />
+          </Rescaler>
+          <Rescaler
+            width={320} height={180} top={top} left={960}
+            transition={{
+              durationMs: 2000,
+              easingFunction: {
+                functionName: 'cubic_bezier',
+                points: [0.33, 1, 0.68, 1],
+              },
+            }}>
+            <InputStream inputId="input_4" />
+          </Rescaler>
+        </View>
+      );
+    }
+    ```
+  </TabItem>
   <TabItem value="http" label="HTTP">
     ```http
     POST: /api/output/output_1/update

--- a/docs/pages/intro.md
+++ b/docs/pages/intro.md
@@ -1,45 +1,17 @@
 # Getting started
 
-## What is Live Compositor?
+TypeScript/React project is the easiest way to start your journey with the Live Compositor.
+To generate project run below command and follow the instructions.
 
-LiveCompositor is a media server for real-time, low latency, programmable video and audio mixing. 
+```bash
+npm create live-compositor@latest
+```
 
-LiveCompositor targets real-time use cases, with a significant focus on situations where latency is critical. It is a great fit
-for any video conferencing, live-streaming, or broadcasting solutions where you need to combine or modify video on the fly.
-However, you can also use it for non-real-time use cases, for example, apply some effect on a video from an MP4 file and write the output 
-to file as MP4.
+If you don't want to use TypeScript SDK you can also use Live Compositor as:
+- [Standalone media server](./intro/how-to-use.md#standalone)
+- [Membrane Framework plugin](./intro/how-to-use.md#membrane-framework-plugin)
 
-## Where to start?
-
-To get started check out our [`Guides`](./category/guides) section that will walk you through common scenarios.
-- [`Quick start`](./guides/quick-start.md) basic video composing and audio mixing setup.
-- [`Deliver input streams`](./guides/deliver-input.md) explains and shows examples of streaming multimedia to the LiveCompositor and use them for mixing/composition.
-- [`Receive output streams`](./guides/receive-output.md) explains and shows examples of receiving streams with results of mixing/composition from the LiveCompositor
-- [`Basic Layouts`](./guides/basic-layouts.md) describes how to achieve a few of the most basic layouts when composing video.
-- [`Transitions (View/Rescaler)`](./guides/view-transition.md) shows a few basic examples of animated transitions on `View`/`Rescaler` components.
-
-The main concept and basic abstractions that the LiveCompositor operates on are described in the [`Concepts`](./concept/overview.md) section.
-
-## How to use it?
-
-Live Compositor can be used standalone or as a part of a Membrane Framework multimedia pipeline.
-
-### Standalone
-
-You can use LiveCompositor as a standalone multimedia server. The server can be started by:
-- Building [`github.com/software-mansion/live-compositor`](https://github.com/software-mansion/live-compositor) from source.
-- Using binaries from [GitHub releases](https://github.com/software-mansion/live-compositor/releases).
-- Using Docker
-  - (recommended) Dockerfile with compositor without web rendering support [https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/slim.Dockerfile](https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/slim.Dockerfile)
-  - Dockerfile with compositor with web rendering support [https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/full.Dockerfile](https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/full.Dockerfile)
-
-### Membrane Framework plugin
-
-Membrane Framework has its own way of handling multimedia, so to fit into that ecosystem some features do not translate one-to-one between standalone compositor and the plugin.
-
-Notable differences:
-- Inputs/outputs in LiveCompositor can include both audio and video at the same time, but with the Membrane plugin you need to create separate inputs/outputs for each media type.
-- No support for MP4 files as input. It is more idiomatic to use Membrane plugins to read MP4 files instead.
-- To connect inputs/outputs to LiveCompositor you need to first register them before sending/receiving the stream, but with the Membrane plugin connecting pads covers both those steps.
-
-Parts of this documentation were written with a standalone scenario in mind, so make sure to always consult [the plugin documentation](https://hexdocs.pm/membrane_live_compositor_plugin/0.9.0/Membrane.LiveCompositor.html) first. For example, to see how to send a scene update check out documentation on `HexDocs`, but if you want to know what options the `View` component supports, then consult the documentation [here](./api/components/View.md).
+Check out:
+- [What is Live Compositor?](./intro/what-is-compositor.md)
+- [How to use it?](./intro/how-to-use.md)
+- [Where to go next?](./intro/where-next.md)

--- a/docs/pages/intro/how-to-use.md
+++ b/docs/pages/intro/how-to-use.md
@@ -1,0 +1,37 @@
+# How to use it?
+
+Live Compositor can be used or deployed in a few ways.
+
+## TypeScript/React
+
+TypeScript SDK currently can only be run in Node.js environment, but browser and React Native support will be added soon. Run
+```
+npm create live-compositor
+```
+to generate a new starter project.
+
+There are 2 NPM packages that you need to be aware of:
+- `live-compositor` package provides React components and hooks to define how streams should be composed.
+- `@live-compositor/node` package provides interface to interact with the Live Compositor server from Node.js environment.
+
+See [TypeScript SDK documentation for more](../typescript/api.md) to learn more.
+
+## Standalone
+
+You can use LiveCompositor as a standalone multimedia server. The server can be started by:
+- Building [`github.com/software-mansion/live-compositor`](https://github.com/software-mansion/live-compositor) from source.
+- Using binaries from [GitHub releases](https://github.com/software-mansion/live-compositor/releases).
+- Using Docker
+  - (recommended) Dockerfile with compositor without web rendering support [https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/slim.Dockerfile](https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/slim.Dockerfile)
+  - Dockerfile with compositor with web rendering support [https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/full.Dockerfile](https://github.com/software-mansion/live-compositor/blob/master/build_tools/docker/full.Dockerfile)
+
+## Membrane Framework plugin
+
+Membrane Framework has its own way of handling multimedia, so to fit into that ecosystem some features do not translate one-to-one between standalone compositor and the plugin.
+
+Notable differences:
+- Inputs/outputs in LiveCompositor can include both audio and video at the same time, but with the Membrane plugin you need to create separate inputs/outputs for each media type.
+- No support for MP4 files as input. It is more idiomatic to use Membrane plugins to read MP4 files instead.
+- To connect inputs/outputs to LiveCompositor you need to first register them before sending/receiving the stream, but with the Membrane plugin connecting pads covers both those steps.
+
+Parts of this documentation were written with a standalone scenario in mind, so make sure to always consult [the plugin documentation](https://hexdocs.pm/membrane_live_compositor_plugin/0.9.0/Membrane.LiveCompositor.html) first. For example, to see how to send a scene update check out documentation on `HexDocs`, but if you want to know what options the `View` component supports, then consult the documentation [here](../api/components/View.md).

--- a/docs/pages/intro/what-is-compositor.md
+++ b/docs/pages/intro/what-is-compositor.md
@@ -1,0 +1,8 @@
+# What is Live Compositor?
+
+LiveCompositor is a media server for real-time, low latency, programmable video and audio mixing.
+
+LiveCompositor targets real-time use cases, with a significant focus on situations where latency is critical. It is a great fit
+for any video conferencing, live-streaming, or broadcasting solutions where you need to combine or modify video on the fly.
+However, you can also use it for non-real-time use cases, for example, apply some effect on a video from an MP4 file and write the output
+to file as MP4.

--- a/docs/pages/intro/where-next.md
+++ b/docs/pages/intro/where-next.md
@@ -1,0 +1,29 @@
+# Where to go next?
+
+## Guides
+
+To get started check out our [`Guides`](../category/guides) section that will walk you through common scenarios.
+- [`Quick start`](../guides/quick-start.md) basic video composing and audio mixing setup.
+- [`Deliver input streams`](../guides/deliver-input.md) explains and shows examples of streaming multimedia to the LiveCompositor and use them for mixing/composition.
+- [`Receive output streams`](../guides/receive-output.md) explains and shows examples of receiving streams with results of mixing/composition from the LiveCompositor
+- [`Basic Layouts`](../guides/basic-layouts.md) describes how to achieve a few of the most basic layouts when composing video.
+- [`Transitions (View/Rescaler)`](../guides/view-transition.md) shows a few basic examples of animated transitions on `View`/`Rescaler` components.
+
+The main concept and basic abstractions that the LiveCompositor operates on are described in the [`Concepts`](../concept/overview.md) section.
+
+## Language specific documentation
+
+There are a few resources that are specific to language/method of deployment. Check out sections below that apply to you.
+
+### TypeScript/React
+
+- [SDK Reference](../typescript/api.md)
+- Check out examples in our [repo](https://github.com/software-mansion/live-compositor/tree/master/ts/examples).
+
+### Standalone
+
+- [HTTP API Reference](../api/routes.md)
+
+### Membrane Framework plugin
+
+- [HexDocs documentation](https://hexdocs.pm/membrane_live_compositor_plugin/readme.html)

--- a/docs/pages/typescript/api.md
+++ b/docs/pages/typescript/api.md
@@ -1,167 +1,57 @@
----
-description: TypeScript SDK Reference
----
+# TypeScript SDK Reference
 
-# Reference
+## `new LiveCompositor()`
 
 Packages like `@live-compositor/node` export `LiveCompositor` class that is a main entity used to interact with or control Live Compositor server instance.
 
-## `LiveCompositor`
+See [LiveCompositor API](./instance.md).
 
-```tsx
-import LiveCompositor from "@live-compositor/node"
-```
+## Components
 
-### `new LiveCompositor()` 
+React components that can be used to define how input streams should be composed.
 
-```tsx
-new LiveCompositor(manager?: CompositorManager)
-```
+- [`InputStream`](./components/InputStream.md)
+- [`View`](./components/View.md)
+- [`Rescaler`](./components/Rescaler.md)
+- [`Tiles`](./components/Tiles.md)
+- [`Text`](./components/Text.md)
+- [`Shader`](./components/Shader.md)
+- [`Image`](./components/Image.md)
+- [`InputStream`](./components/WebView.md)
 
-Creates new compositor configuration. You have to call `init` first before this object can be used.
+You can't use DOM components like `<div/>` when composing streams. React code can only use LiveCompositor specific components.
 
+## Hooks
 
-`CompositorManager` configures how the client code will connect and manage the LiveCompositor server.
-- (**default**) `LocallySpawnedInstance` from `@live-compositor/node` downloads LiveCompositor binaries and starts the server on the local machine.
-- `ExistingInstance` from `@live-compositor/node` connects to already existing compositor instance.
+React hooks that can be used in React code that controls stream composition.
 
-### `init()`
+- [`useInputStreams`](./hooks.md#useinputstreams)
+- [`useInputAudio`](./hooks.md#useinputaudio)
 
-```tsx
-LiveCompositor.init(): Promise<void>
-```
+You can also use regular React hooks like `useState`, `useEffect` and others.
 
-Initialize the LiveCompositor instance, depending on which `CompositorManager` you are using it might mean spawning
-new instance or just establishing connection.
+## Renderers
 
-After this request you can start connecting inputs/outputs or register other elements. However, no output stream will
-be produced until `start()` method is called.
+Functionality that can be used when composing streams, but it has to be registered first e.g. `Shader` needs to be registered first before you use `<Shader>` component.
 
-### `start()`
+- [`Shader`](./renderers/shader.md)
+- [`Image`](./renderers/image.md)
+- [`WebRenderer`](./renderers/web.md)
 
-```tsx
-LiveCompositor.start(): Promise<void>
-```
+## Inputs
 
-Starts the processing pipeline. Any previously registered output will start producing the video/audio stream.
+To deliver video/audio to the compositor you need to register some inputs. Registered stream can be used in composition using `<InputStream inputId="example_input" />` component. 
 
-***
+- [`RTP`](./inputs/rtp.md)
+- [`MP4`](./inputs/mp4.md)
 
-### Outputs configuration
+You can register an input with [`LiveCompositor.registerInput`](./instance#register-input)
 
-#### Register output
+## Outputs
 
-```tsx
-import { Outputs } from "live-compositor"
+Defines protocol, format and destination of the composed video and mixed audio streams.
 
-LiveCompositor.registerOutput(
-  outputId: string,
-  output: Outputs.RegisterOutput,
-): Promise<object>
-```
+- [`RTP`](./outputs/rtp.md)
+- [`MP4`](./outputs/mp4.md)
 
-Register external destination that can be used as a compositor output. See outputs documentation to learn more:
-- [Rtp](./outputs/rtp.md)
-- [Mp4](./outputs/mp4.md)
-
-#### Unregister output
-
-```tsx
-LiveCompositor.unregisterOutput(outputId: string): Promise<void>
-```
-
-Unregister previously registered output.
-
-***
-
-### Inputs configuration
-
-#### Register input
-
-```tsx
-import { Inputs } from "live-compositor"
-
-LiveCompositor.registerInput(
-  inputId: string,
-  input: Inputs.RegisterInput,
-): Promise<object>
-```
-
-Register external source that can be used as a compositor input. See inputs documentation to learn more:
-- [RTP](./inputs/rtp.md)
-- [MP4](./inputs/mp4.md)
-
-#### Unregister input
-
-```tsx
-LiveCompositor.unregisterInput(inputId: string): Promise<void>
-```
-
-Unregister a previously registered input. 
-
-***
-
-### Renderers configuration
-
-#### Register image
-
-```tsx
-import { Renderers } from "live-compositor"
-
-LiveCompositor.registerImage(
-  imageId: string,
-  image: Renderers.RegisterImage,
-): Promise<void>
-```
-
-Register an image asset. See [`Renderers.RegisterImage`](./renderers/image.md) to learn more.
-
-#### Unregister image
-
-```tsx
-LiveCompositor.unregisterImage(imageId: string): Promise<void>
-```
-
-Unregister a previously registered image asset. 
-
-#### Register shader
-
-```tsx
-import { Renderers } from "live-compositor"
-
-LiveCompositor.registerShader(
-  shaderId: string,
-  shader: Renderers.RegisterShader,
-): Promise<void>
-```
-
-Register a shader. See [`Renderers.RegisterShader`](./renderers/shader.md) to learn more.
-
-#### Unregister shader
-
-```tsx
-LiveCompositor.unregisterShader(shaderId: string): Promise<void>
-```
-
-Unregister a previously registered shader. 
-
-#### Register web renderer instance
-
-```tsx
-import { Renderers } from "live-compositor"
-
-LiveCompositor.registerWebRenderer(
-  instanceId: string,
-  instance: Renderers.RegisterWebRenderer,
-): Promise<object>
-```
-
-Register a web renderer instance. See [`Renderer.RegisterWebRenderer`](./renderers/web.md) to learn more.
-
-#### Unregister web renderer instance
-
-```tsx
-LiveCompositor.unregisterWebRenderer(instanceId: string): Promise<void>
-```
-
-Unregister a previously registered web renderer. 
+You can register an output with [`LiveCompositor.registerOutput`](./instance#register-output)

--- a/docs/pages/typescript/components/Image.md
+++ b/docs/pages/typescript/components/Image.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 A component for rendering images.
 
 :::note
-To use this component, you need to first register the image with matching `imageId` using [`LiveCompositor.registerImage`](../api.md#register-image) request.
+To use this component, you need to first register the image with matching `imageId` using [`LiveCompositor.registerImage`](../instance.md#register-image) request.
 :::
 
 ## ImageProps
@@ -21,4 +21,4 @@ type ImageProps = {
 
 #### Properties
 - `id` - Id of a component. Defaults to value produced by `useId` hook.
-- `imageId` - Id of an image. It identifies an image registered using a [`LiveCompositor.registerImage`](../api.md#register-image) method.
+- `imageId` - Id of an image. It identifies an image registered using a [`LiveCompositor.registerImage`](../instance.md#register-image) method.

--- a/docs/pages/typescript/components/InputStream.md
+++ b/docs/pages/typescript/components/InputStream.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 `InputStream` component represents a registered input.
 
 :::note
-To use this component, you need to first register the stream with matching `inputId` using [`LiveCompositor.registerInput`](../api.md#register-input) method.
+To use this component, you need to first register the stream with matching `inputId` using [`LiveCompositor.registerInput`](../instance.md#register-input) method.
 :::
 
 ## Props
@@ -22,6 +22,6 @@ type InputStreamProps = {
 ```
 
 - `id` - Id of a component. Defaults to value produced by `useId` hook.
-- `inputId` - Id of an input. It identifies a stream registered using a [`LiveCompositor.registerInput`](../api.md#register-input) method.
+- `inputId` - Id of an input. It identifies a stream registered using a [`LiveCompositor.registerInput`](../instance.md#register-input) method.
 - `volume` - (**default=`1`**) Audio volume represented by a number between 0 and 1.
 - `mute` - (**default=`false`**) Mute audio.

--- a/docs/pages/typescript/components/Shader.md
+++ b/docs/pages/typescript/components/Shader.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 `Shader` applies transformation defined via WGSL shader on its children. [Learn more.](../../concept/shaders.md)
 
 :::note
-To use this component, you need to first register the shader with matching `shaderId` using [`LiveCompositor.registerShader`](../api.md#register-shader) method.
+To use this component, you need to first register the shader with matching `shaderId` using [`LiveCompositor.registerShader`](../instance.md#register-shader) method.
 :::
 
 ## ShaderProps
@@ -26,7 +26,7 @@ type ShaderProps = {
 
 - `id` - Id of a component. Defaults to value produced by `useId` hook.
 - `children` - List of component's children.
-- `shaderId` - Id of a shader. It identifies a shader registered using a [`LiveCompositor.registerShader`](../api.md#register-shader) method.
+- `shaderId` - Id of a shader. It identifies a shader registered using a [`LiveCompositor.registerShader`](../instance.md#register-shader) method.
 - `shaderParam` - Object that will be serialized into a `struct` and passed inside the shader as:
   
   ```wgsl

--- a/docs/pages/typescript/components/WebView.md
+++ b/docs/pages/typescript/components/WebView.md
@@ -10,7 +10,7 @@ title: WebView
 `WebView` renders a website using Chromium engine embedded inside the compositor.
 
 :::note
-To use this component, you need to first register the web renderer instance with matching `instanceId` using [`LiveCompositor.registerWebRenderer`](../api.md#register-web-renderer-instance) method.
+To use this component, you need to first register the web renderer instance with matching `instanceId` using [`LiveCompositor.registerWebRenderer`](../instance.md#register-web-renderer-instance) method.
 :::
 
 :::warning
@@ -31,7 +31,7 @@ WebView component renders a website using Chromium Embedded Framework (CEF).
 
 - `id` - Id of a component. Defaults to value produced by `useId` hook.
 - `children` - List of component's children.
-- `instanceId` - Id of a web renderer instance. It identifies an instance registered using a [`LiveCompositor.registerWebRenderer`](../api.md#register-web-renderer-instance) request.
+- `instanceId` - Id of a web renderer instance. It identifies an instance registered using a [`LiveCompositor.registerWebRenderer`](../instance.md#register-web-renderer-instance) request.
   
   :::warning
   You can only refer to specific instances in one Component at a time.

--- a/docs/pages/typescript/instance.md
+++ b/docs/pages/typescript/instance.md
@@ -1,0 +1,161 @@
+# `LiveCompositor`
+
+Packages like `@live-compositor/node` export `LiveCompositor` class that is a main entity used to interact with or control Live Compositor server instance.
+
+```tsx
+import LiveCompositor from "@live-compositor/node"
+```
+
+### `new LiveCompositor()`
+
+```tsx
+new LiveCompositor(manager?: CompositorManager)
+```
+
+Creates new compositor configuration. You have to call `init` first before this object can be used.
+
+
+`CompositorManager` configures how the client code will connect and manage the LiveCompositor server.
+- (**default**) `LocallySpawnedInstance` from `@live-compositor/node` downloads LiveCompositor binaries and starts the server on the local machine.
+- `ExistingInstance` from `@live-compositor/node` connects to already existing compositor instance.
+
+### `init()`
+
+```tsx
+LiveCompositor.init(): Promise<void>
+```
+
+Initialize the LiveCompositor instance, depending on which `CompositorManager` you are using it might mean spawning
+new instance or just establishing connection.
+
+After this request you can start connecting inputs/outputs or register other elements. However, no output stream will
+be produced until `start()` method is called.
+
+### `start()`
+
+```tsx
+LiveCompositor.start(): Promise<void>
+```
+
+Starts the processing pipeline. Any previously registered output will start producing the video/audio stream.
+
+***
+
+### Outputs configuration
+
+#### Register output
+
+```tsx
+import { Outputs } from "live-compositor"
+
+LiveCompositor.registerOutput(
+  outputId: string,
+  output: Outputs.RegisterOutput,
+): Promise<object>
+```
+
+Register external destination that can be used as a compositor output. See outputs documentation to learn more:
+- [Rtp](./outputs/rtp.md)
+- [Mp4](./outputs/mp4.md)
+
+#### Unregister output
+
+```tsx
+LiveCompositor.unregisterOutput(outputId: string): Promise<void>
+```
+
+Unregister previously registered output.
+
+***
+
+### Inputs configuration
+
+#### Register input
+
+```tsx
+import { Inputs } from "live-compositor"
+
+LiveCompositor.registerInput(
+  inputId: string,
+  input: Inputs.RegisterInput,
+): Promise<object>
+```
+
+Register external source that can be used as a compositor input. See inputs documentation to learn more:
+- [RTP](./inputs/rtp.md)
+- [MP4](./inputs/mp4.md)
+
+#### Unregister input
+
+```tsx
+LiveCompositor.unregisterInput(inputId: string): Promise<void>
+```
+
+Unregister a previously registered input.
+
+***
+
+### Renderers configuration
+
+#### Register image
+
+```tsx
+import { Renderers } from "live-compositor"
+
+LiveCompositor.registerImage(
+  imageId: string,
+  image: Renderers.RegisterImage,
+): Promise<void>
+```
+
+Register an image asset. See [`Renderers.RegisterImage`](./renderers/image.md) to learn more.
+
+#### Unregister image
+
+```tsx
+LiveCompositor.unregisterImage(imageId: string): Promise<void>
+```
+
+Unregister a previously registered image asset.
+
+#### Register shader
+
+```tsx
+import { Renderers } from "live-compositor"
+
+LiveCompositor.registerShader(
+  shaderId: string,
+  shader: Renderers.RegisterShader,
+): Promise<void>
+```
+
+Register a shader. See [`Renderers.RegisterShader`](./renderers/shader.md) to learn more.
+
+#### Unregister shader
+
+```tsx
+LiveCompositor.unregisterShader(shaderId: string): Promise<void>
+```
+
+Unregister a previously registered shader.
+
+#### Register web renderer instance
+
+```tsx
+import { Renderers } from "live-compositor"
+
+LiveCompositor.registerWebRenderer(
+  instanceId: string,
+  instance: Renderers.RegisterWebRenderer,
+): Promise<object>
+```
+
+Register a web renderer instance. See [`Renderer.RegisterWebRenderer`](./renderers/web.md) to learn more.
+
+#### Unregister web renderer instance
+
+```tsx
+LiveCompositor.unregisterWebRenderer(instanceId: string): Promise<void>
+```
+
+Unregister a previously registered web renderer.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -4,8 +4,28 @@ const sidebars: SidebarsConfig = {
   sidebar: [
     {
       label: 'Getting started',
-      type: 'doc',
-      id: 'intro',
+      type: 'category',
+      link: {
+        type: 'doc',
+        id: 'intro',
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'intro/what-is-compositor',
+          label: 'What is Live Compositor?',
+        },
+        {
+          type: 'doc',
+          id: 'intro/how-to-use',
+          label: 'How to use it?',
+        },
+        {
+          type: 'doc',
+          id: 'intro/where-next',
+          label: 'Where to go next?',
+        },
+      ],
     },
     {
       type: 'category',
@@ -97,7 +117,12 @@ const sidebars: SidebarsConfig = {
         {
           type: 'ref',
           id: 'typescript/api',
-          label: 'LiveCompositor instance',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'typescript/instance',
+          label: 'new LiveCompositor()',
         },
         {
           type: 'doc',

--- a/docs/src/components/ExampleSceneJsx.tsx
+++ b/docs/src/components/ExampleSceneJsx.tsx
@@ -3,7 +3,7 @@ import CodeBlock from '@theme/CodeBlock';
 const JSX_CODE = `import {
   InputStream,
   Image,
-  Rescaler
+  Rescaler,
   Shader,
   Text,
   View,
@@ -22,7 +22,9 @@ function Example() {
         <InputStream inputId="bunny" />
       </Rescaler>
       <View
-        bottom={0} left={0} height={120}
+        bottom={0}
+        left={0}
+        height={120}
         backgroundColor="#B3B3B3">
         <View />
         <Text fontSize={100} weight="bold" color="#000000">

--- a/docs/src/components/ExampleSceneJsx.tsx
+++ b/docs/src/components/ExampleSceneJsx.tsx
@@ -21,7 +21,9 @@ function Example() {
       <Rescaler top={20} left={20} width={640} height={360}>
         <InputStream inputId="bunny" />
       </Rescaler>
-      <View bottom={0} left={0} height={120}>
+      <View
+        bottom={0} left={0} height={120}
+        backgroundColor="#B3B3B3">
         <View />
         <Text fontSize={100} weight="bold" color="#000000">
           LiveCompositor 😃😍

--- a/docs/src/components/ExampleSceneJsx.tsx
+++ b/docs/src/components/ExampleSceneJsx.tsx
@@ -1,0 +1,38 @@
+import CodeBlock from '@theme/CodeBlock';
+
+const JSX_CODE = `import {
+  InputStream,
+  Image,
+  Rescaler
+  Shader,
+  Text,
+  View,
+} from "live-compositor"
+
+function Example() {
+  return (
+    <View>
+      <Shader
+        shaderId="replace_green_screen"
+        resolution={{ width: 1920, height: 1080 }}>
+        <InputStream inputId="tv" />
+        <Image imageId="background" />
+      </Shader>
+      <Rescaler top={20} left={20} width={640} height={360}>
+        <InputStream inputId="bunny" />
+      </Rescaler>
+      <View bottom={0} left={0} height={120}>
+        <View />
+        <Text fontSize={100} weight="bold" color="#000000">
+          LiveCompositor 😃😍
+        </Text>
+        <View />
+      </View>
+    </View>
+  );
+}
+`;
+
+export default function ExampleSceneJsx() {
+  return <CodeBlock language="tsx">{JSX_CODE}</CodeBlock>;
+}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 import Layout from '@theme/Layout';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import clsx from 'clsx';
 import { FaServer } from 'react-icons/fa';
 import { FaBook, FaCode, FaDocker, FaGears, FaGithub, FaLink } from 'react-icons/fa6';
@@ -21,6 +23,7 @@ import { PropsWithChildren } from 'react';
 import { IconContext, IconType } from 'react-icons';
 import TypewriterComponent from 'typewriter-effect';
 import ExampleSceneJson from '../components/ExampleSceneJson';
+import ExampleSceneJsx from '../components/ExampleSceneJsx';
 import styles from './index.module.css';
 
 function HomepageHeader() {
@@ -107,12 +110,19 @@ function HowItWorks() {
         <br />
         3. Get the mixed streams via RTP
       </p>
-      <div className="row" style={{ alignItems: 'center' }}>
-        <div className="col col--6">
+      <div className="flex flex-row flex-wrap">
+        <div className="flex-1 mx-8 mt-20 min-w-[400px]">
           <img src={ComposingImg} alt="Composing" />
         </div>
-        <div className={clsx('col col--6', styles.sceneExample)}>
-          <ExampleSceneJson />
+        <div className="flex-1">
+          <Tabs>
+            <TabItem value="react" label="React" default>
+              <ExampleSceneJsx />
+            </TabItem>
+            <TabItem value="json" label="JSON">
+              <ExampleSceneJson />
+            </TabItem>
+          </Tabs>
         </div>
       </div>
     </div>

--- a/ts/live-compositor/src/components/common.ts
+++ b/ts/live-compositor/src/components/common.ts
@@ -26,7 +26,7 @@ export type EasingFunction =
   | { functionName: 'linear' }
   | { functionName: 'bounce' }
   | {
-      functionName: 'cubic-bezier';
+      functionName: 'cubic_bezier';
       points: [number, number, number, number];
     };
 
@@ -38,7 +38,7 @@ export function intoApiEasingFunction(easing: EasingFunction): Api.EasingFunctio
     (easing.functionName === 'linear' || easing.functionName == 'bounce')
   ) {
     return { function_name: easing.functionName };
-  } else if (typeof easing === 'object' && easing.functionName === 'cubic-bezier') {
+  } else if (typeof easing === 'object' && easing.functionName === 'cubic_bezier') {
     return {
       function_name: 'cubic_bezier',
       points: easing.points,


### PR DESCRIPTION
- Add React version of guides. It is not perfect there are still some places in those guides when we refer to input_id but it should be `inputId`, but reworking that would take to much time.
- Rework intro section to start promoting typescript as the primary way of using a compositor
- Add React code example to the main page

## API changes

- changed `cubic-bezier` back to `cubic_bezier`. We don't rename other values (we rename only field names) so for consistency lets stay with underscore