### PR TITLE
Switch to SRGB textures + add padding to outptu texture

### DIFF
--- a/compositor_render/src/transformations/layout/apply_layouts.wgsl
+++ b/compositor_render/src/transformations/layout/apply_layouts.wgsl
@@ -76,7 +76,7 @@ struct LayoutInfo {
 
 @group(0) @binding(0) var texture: texture_2d<f32>;
 
-@group(1) @binding(0) var<uniform> output_resolution: vec2<f32>;
+@group(1) @binding(0) var<uniform> output_resolution: vec4<f32>;
 @group(1) @binding(1) var<uniform> texture_params: array<TextureParams, 100>;
 @group(1) @binding(2) var<uniform> color_params: array<ColorParams, 100>;
 @group(1) @binding(3) var<uniform> box_shadow_params: array<BoxShadowParams, 100>;

--- a/compositor_render/src/transformations/text_renderer.rs
+++ b/compositor_render/src/transformations/text_renderer.rs
@@ -82,7 +82,7 @@ impl TextRendererNode {
         let mut viewport = glyphon::Viewport::new(&renderer_ctx.wgpu_ctx.device, cache);
         viewport.update(&renderer_ctx.wgpu_ctx.queue, self.resolution.into());
 
-        let swapchain_format = TextureFormat::Rgba8Unorm;
+        let swapchain_format = TextureFormat::Rgba8UnormSrgb;
         let mut atlas = TextAtlas::new(
             &renderer_ctx.wgpu_ctx.device,
             &renderer_ctx.wgpu_ctx.queue,

--- a/compositor_render/src/wgpu/common_pipeline.rs
+++ b/compositor_render/src/wgpu/common_pipeline.rs
@@ -118,7 +118,7 @@ pub fn create_render_pipeline(
             module: shader_module,
             entry_point: crate::wgpu::common_pipeline::FRAGMENT_ENTRYPOINT_NAME,
             targets: &[Some(wgpu::ColorTargetState {
-                format: wgpu::TextureFormat::Rgba8Unorm,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
                 write_mask: wgpu::ColorWrites::all(),
                 blend: Some(wgpu::BlendState::ALPHA_BLENDING),
             })],

--- a/compositor_render/src/wgpu/format/interleaved_yuv_to_rgba.rs
+++ b/compositor_render/src/wgpu/format/interleaved_yuv_to_rgba.rs
@@ -42,7 +42,7 @@ impl InterleavedYuv422ToRgbaConverter {
                 module: &shader_module,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     write_mask: wgpu::ColorWrites::all(),
                     blend: None,
                 })],

--- a/compositor_render/src/wgpu/format/nv12_to_rgba.rs
+++ b/compositor_render/src/wgpu/format/nv12_to_rgba.rs
@@ -41,7 +41,7 @@ impl Nv12ToRgbaConverter {
                 module: &shader_module,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     write_mask: wgpu::ColorWrites::all(),
                     blend: None,
                 })],

--- a/compositor_render/src/wgpu/format/planar_yuv_to_rgba.rs
+++ b/compositor_render/src/wgpu/format/planar_yuv_to_rgba.rs
@@ -47,7 +47,7 @@ impl PlanarYuvToRgbaConverter {
                 module: &shader_module,
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    format: wgpu::TextureFormat::Rgba8UnormSrgb,
                     write_mask: wgpu::ColorWrites::all(),
                     blend: None,
                 })],

--- a/compositor_render/src/wgpu/format/planar_yuv_to_rgba.wgsl
+++ b/compositor_render/src/wgpu/format/planar_yuv_to_rgba.wgsl
@@ -32,6 +32,14 @@ struct PushConstantParams {
 
 var<push_constant> params: PushConstantParams;
 
+fn srgb_to_linear(srgb: vec3<f32>) -> vec3<f32> {
+    let cutoff = step(srgb, vec3(0.04045));
+    let higher = pow((srgb + vec3<f32>(0.055))/vec3<f32>(1.055), vec3<f32>(2.4));
+    let lower = srgb/vec3(12.92);
+
+    return mix(higher, lower, cutoff);
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     var y = textureSample(y_texture, sampler_, input.tex_coords).x;
@@ -50,5 +58,6 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
     let g = y - 0.34414 * (u - 128.0 / 255.0) - 0.71414 * (v - 128.0 / 255.0);
     let b = y + 1.77200 * (u - 128.0 / 255.0);
 
-    return vec4(clamp(r, 0.0, 1.0), clamp(g, 0.0, 1.0), clamp(b, 0.0, 1.0), 1.0);
+    let srgb = vec3<f32>(clamp(r, 0.0, 1.0), clamp(g, 0.0, 1.0), clamp(b, 0.0, 1.0));
+    return vec4(srgb_to_linear(srgb), 1.0);
 }

--- a/compositor_render/src/wgpu/format/rgba_to_yuv.wgsl
+++ b/compositor_render/src/wgpu/format/rgba_to_yuv.wgsl
@@ -23,26 +23,35 @@ fn vs_main(input: VertexInput) -> VertexOutput {
 
 var<push_constant> plane_selector: u32;
 
+fn linear_to_srgb(linear: vec3<f32>) -> vec3<f32> {
+    let cutoff = step(linear, vec3<f32>(0.0031308));
+    let higher = vec3<f32>(1.055)*pow(linear, vec3<f32>(1.0/2.4)) - vec3<f32>(0.055);
+    let lower = linear * vec3<f32>(12.92);
+
+    return mix(higher, lower, cutoff);
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) f32 {
-    let color = textureSample(texture, sampler_, input.tex_coords);
-    var conversion_weights: vec4<f32>;
+    let linear = textureSample(texture, sampler_, input.tex_coords);
+    let color = linear_to_srgb(linear.rgb);
+    var conversion_weights: vec3<f32>;
     var conversion_bias: f32;
 
     if(plane_selector == 0u) {
         // Y
-        conversion_weights = vec4<f32>(0.299, 0.587, 0.114, 0.0);
+        conversion_weights = vec3<f32>(0.299, 0.587, 0.114);
         conversion_bias = 0.0;
     } else if(plane_selector == 1u) {
         // U
-        conversion_weights = vec4<f32>(-0.168736, -0.331264, 0.5, 0.0);
+        conversion_weights = vec3<f32>(-0.168736, -0.331264, 0.5);
         conversion_bias = 128.0 / 255.0;
     } else if(plane_selector == 2u) {
         // V
-        conversion_weights = vec4<f32>(0.5, -0.418688, -0.081312, 0.0);
+        conversion_weights = vec3<f32>(0.5, -0.418688, -0.081312);
         conversion_bias = 128.0 / 255.0;
     } else {
-        conversion_weights = vec4<f32>();
+        conversion_weights = vec3<f32>();
     }
 
     return clamp(dot(color, conversion_weights) + conversion_bias, 0.0, 1.0);

--- a/compositor_render/src/wgpu/texture/base.rs
+++ b/compositor_render/src/wgpu/texture/base.rs
@@ -94,7 +94,7 @@ impl Texture {
                 height: 1,
                 depth_or_array_layers: 1,
             },
-            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
             wgpu::TextureUsages::TEXTURE_BINDING,
         )
     }

--- a/compositor_render/src/wgpu/texture/bgra.rs
+++ b/compositor_render/src/wgpu/texture/bgra.rs
@@ -15,7 +15,7 @@ impl BGRATexture {
                 height: resolution.height as u32,
                 depth_or_array_layers: 1,
             },
-            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
             wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::TEXTURE_BINDING,
         ))
     }

--- a/compositor_render/src/wgpu/texture/interleaved_yuv422.rs
+++ b/compositor_render/src/wgpu/texture/interleaved_yuv422.rs
@@ -27,7 +27,7 @@ impl InterleavedYuv422Texture {
                 // g - y1
                 // b - v
                 // a - y2
-                wgpu::TextureFormat::Rgba8Unorm,
+                wgpu::TextureFormat::Rgba8UnormSrgb,
                 wgpu::TextureUsages::RENDER_ATTACHMENT
                     | wgpu::TextureUsages::COPY_DST
                     | wgpu::TextureUsages::COPY_SRC

--- a/compositor_render/src/wgpu/texture/rgba.rs
+++ b/compositor_render/src/wgpu/texture/rgba.rs
@@ -18,7 +18,7 @@ impl RGBATexture {
                 height: resolution.height as u32,
                 depth_or_array_layers: 1,
             },
-            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
             wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC

--- a/compositor_web/Cargo.toml
+++ b/compositor_web/Cargo.toml
@@ -36,3 +36,6 @@ glyphon = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = true

--- a/compositor_web/src/wasm/input_uploader.rs
+++ b/compositor_web/src/wasm/input_uploader.rs
@@ -97,8 +97,8 @@ impl InputUploader {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC

--- a/integration_tests/examples/raw_channel_input.rs
+++ b/integration_tests/examples/raw_channel_input.rs
@@ -204,12 +204,12 @@ fn create_texture(index: usize, device: &wgpu::Device, queue: &wgpu::Queue) -> A
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba8Unorm,
+        format: wgpu::TextureFormat::Rgba8UnormSrgb,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT
             | wgpu::TextureUsages::COPY_DST
             | wgpu::TextureUsages::COPY_SRC
             | wgpu::TextureUsages::TEXTURE_BINDING,
-        view_formats: &[wgpu::TextureFormat::Rgba8Unorm],
+        view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
     });
 
     queue.write_texture(


### PR DESCRIPTION
- Fix passing output_resolution with WASM (alignment to 16 bytes)
- Switch all textures to srgb

Snapshots: https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/46