### PR TITLE
Remove spec-compliant reference picture list init and modification.

### DIFF
--- a/vk-video/src/parser.rs
+++ b/vk-video/src/parser.rs
@@ -21,8 +21,7 @@ mod reference_manager;
 #[derivative(Debug)]
 #[allow(non_snake_case)]
 pub struct DecodeInformation {
-    pub(crate) reference_list_l0: Option<Vec<ReferencePictureInfo>>,
-    pub(crate) reference_list_l1: Option<Vec<ReferencePictureInfo>>,
+    pub(crate) reference_list: Option<Vec<ReferencePictureInfo>>,
     #[derivative(Debug = "ignore")]
     pub(crate) rbsp_bytes: Vec<u8>,
     pub(crate) slice_indices: Vec<usize>,

--- a/vk-video/src/vulkan_decoder.rs
+++ b/vk-video/src/vulkan_decoder.rs
@@ -813,10 +813,9 @@ impl VulkanDecoder<'_> {
         decode_information: &DecodeInformation,
     ) -> Vec<vk::native::StdVideoDecodeH264ReferenceInfo> {
         decode_information
-            .reference_list_l0
+            .reference_list
             .iter()
             .flatten()
-            .chain(decode_information.reference_list_l1.iter().flatten())
             .map(|&ref_info| ref_info.into())
             .collect::<Vec<_>>()
     }
@@ -838,10 +837,9 @@ impl VulkanDecoder<'_> {
     ) -> Result<Vec<vk::VideoReferenceSlotInfoKHR<'a>>, VulkanDecoderError> {
         let mut pic_reference_slots: Vec<vk::VideoReferenceSlotInfoKHR<'a>> = Vec::new();
         for (ref_info, dpb_slot_info) in decode_information
-            .reference_list_l0
+            .reference_list
             .iter()
             .flatten()
-            .chain(decode_information.reference_list_l1.iter().flatten())
             .zip(references_dpb_slot_info.iter_mut())
         {
             let i = *reference_id_to_dpb_slot_index


### PR DESCRIPTION
Turns out these parts don't need to be done exactly according to the spec. The vulkan docs are not very clear on this unfortunately, but it seems to work.