### PR TITLE
[ts-sdk] Fix WASM types generation

### DIFF
--- a/.github/workflows/ts_sdk_check.yml
+++ b/.github/workflows/ts_sdk_check.yml
@@ -19,6 +19,11 @@ jobs:
             - name: Checkout repo
               uses: actions/checkout@v2
 
+            - name: 🔧 Install the rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: 1.81.0
+
             - name: Install pnpm
               uses: pnpm/action-setup@v4
               with: 

--- a/compositor_web/Cargo.toml
+++ b/compositor_web/Cargo.toml
@@ -17,7 +17,7 @@ tracing-subscriber = "0.2.19"
 log = { workspace = true }
 wasm-log = "0.3.1"
 js-sys = "0.3.69"
-wasm-bindgen = "0.2.92"
+wasm-bindgen = "0.2.95"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
     "Document",

--- a/ts/package.json
+++ b/ts/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm -r run build",
     "build:sdk": "pnpm -C @live-compositor/core run build && pnpm -C @live-compositor/node run build && pnpm -C @live-compositor/web-wasm run build && pnpm -C live-compositor run build",
     "build:all": "pnpm -C @live-compositor/browser-render run build-wasm && pnpm -r run build",
-    "typecheck": "pnpm -r --filter '!@live-compositor/browser-render' run typecheck",
+    "typecheck": "pnpm -r run typecheck",
     "clean": "pnpm -r run clean",
     "watch": "pnpm -r --parallel --stream run watch",
     "generate-types": "node ./scripts/generateTypes.mjs"


### PR DESCRIPTION
There is some regression around version of Rust and wasm-bindgen that is causin `Result` type to be converted to `Array`