### PR TITLE
[ts-sdk] Add offline processing

### DIFF
--- a/build_tools/nix/flake.nix
+++ b/build_tools/nix/flake.nix
@@ -77,7 +77,7 @@
               # Fixes "ffplay" used in examples on Linux (not needed on NixOS)
               env.LIBGL_DRIVERS_PATH = "${pkgs.mesa.drivers}/lib/dri";
 
-              env.LIBCLANG_PATH = "${pkgs.llvmPackages_16.libclang.lib}/lib";
+              env.LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
               env.LD_LIBRARY_PATH = lib.makeLibraryPath (libcefDependencies ++ [ pkgs.mesa.drivers pkgs.libGL pkgs.blackmagic-desktop-video ]);
 
               inputsFrom = [ packageWithoutChromium ];
@@ -89,7 +89,7 @@
             nixos = pkgs.mkShell {
               packages = devDependencies ++ [ pkgs.blackmagic-desktop-video];
 
-              env.LIBCLANG_PATH = "${pkgs.llvmPackages_16.libclang.lib}/lib";
+              env.LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
               env.LD_LIBRARY_PATH = lib.makeLibraryPath (libcefDependencies ++ [ pkgs.blackmagic-desktop-video ]);
 
               inputsFrom = [ packageWithoutChromium ];

--- a/build_tools/nix/package.nix
+++ b/build_tools/nix/package.nix
@@ -2,7 +2,7 @@
 , ffmpeg_7-headless
 , openssl
 , pkg-config
-, llvmPackages_16
+, llvmPackages
 , libGL
 , cmake
 , libopus
@@ -20,6 +20,7 @@ let
     libopus
     libGL
     vulkan-loader
+    stdenv.cc.cc
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Metal
     darwin.apple_sdk.frameworks.Foundation
@@ -43,9 +44,9 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   inherit buildInputs;
-  nativeBuildInputs = [ pkg-config llvmPackages_16.clang cmake makeWrapper ];
+  nativeBuildInputs = [ pkg-config llvmPackages.clang cmake makeWrapper ];
 
-  env.LIBCLANG_PATH = "${llvmPackages_16.libclang.lib}/lib";
+  env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   postFixup =
     ''

--- a/ts/@live-compositor/core/src/api.ts
+++ b/ts/@live-compositor/core/src/api.ts
@@ -34,11 +34,14 @@ export class ApiClient {
     });
   }
 
-  public async unregisterOutput(outptuId: string): Promise<object> {
+  public async unregisterOutput(
+    outptuId: string,
+    body: { schedule_time_ms?: number }
+  ): Promise<object> {
     return this.serverManager.sendRequest({
       method: 'POST',
       route: `/api/output/${encodeURIComponent(outptuId)}/unregister`,
-      body: {},
+      body,
     });
   }
 

--- a/ts/@live-compositor/core/src/compositorManager.ts
+++ b/ts/@live-compositor/core/src/compositorManager.ts
@@ -1,7 +1,14 @@
 import type { ApiRequest } from './api.js';
 
+export interface SetupInstanceOptions {
+  /**
+   * sets LIVE_COMPOSITOR_AHEAD_OF_TIME_PROCESSING_ENABLE environment variable.
+   */
+  aheadOfTimeProcessing: boolean;
+}
+
 export interface CompositorManager {
-  setupInstance(): Promise<void>;
+  setupInstance(opts: SetupInstanceOptions): Promise<void>;
   sendRequest(request: ApiRequest): Promise<object>;
   registerEventListener(cb: (event: unknown) => void): void;
 }

--- a/ts/@live-compositor/core/src/event.ts
+++ b/ts/@live-compositor/core/src/event.ts
@@ -40,7 +40,7 @@ export function onCompositorEvent(store: InstanceContextStore, rawEvent: unknown
   }
 }
 
-function parseEvent(event: any): CompositorEvent | null {
+export function parseEvent(event: any): CompositorEvent | null {
   if (!event.type) {
     console.error(`Malformed event: ${event}`);
     return null;
@@ -56,7 +56,7 @@ function parseEvent(event: any): CompositorEvent | null {
   ) {
     return { type: event.type, inputId: event.input_id };
   } else if (CompositorEventType.OUTPUT_DONE === event.type) {
-    return { type: event.type, outputId: event.outputId };
+    return { type: event.type, outputId: event.output_id };
   } else {
     console.error(`Unknown event type: ${event.type}`);
     return null;

--- a/ts/@live-compositor/core/src/index.ts
+++ b/ts/@live-compositor/core/src/index.ts
@@ -1,5 +1,6 @@
 export { ApiClient, ApiRequest } from './api.js';
-export { LiveCompositor } from './compositor.js';
-export { CompositorManager } from './compositorManager.js';
+export { LiveCompositor } from './live/compositor.js';
+export { OfflineCompositor } from './offline/compositor.js';
+export { CompositorManager, SetupInstanceOptions } from './compositorManager.js';
 export { RegisterInputRequest, RegisterInput } from './api/input.js';
 export { RegisterOutputRequest, RegisterOutput } from './api/output.js';

--- a/ts/@live-compositor/core/src/offline/compositor.ts
+++ b/ts/@live-compositor/core/src/offline/compositor.ts
@@ -1,0 +1,103 @@
+import type { Renderers } from 'live-compositor';
+import { _liveCompositorInternals, CompositorEventType } from 'live-compositor';
+import { ApiClient } from '../api.js';
+import type { CompositorManager } from '../compositorManager.js';
+import type { RegisterOutput } from '../api/output.js';
+import { intoRegisterOutput } from '../api/output.js';
+import type { RegisterInput } from '../api/input.js';
+import { intoRegisterInput } from '../api/input.js';
+import { intoRegisterImage, intoRegisterWebRenderer } from '../api/renderer.js';
+import OfflineOutput from './output.js';
+import { parseEvent } from '../event.js';
+
+/**
+ * Offline rendering only supports one output, so we can just pick any value to use
+ * as an output ID.
+ */
+const OFFLINE_OUTPUT_ID = 'offline_output';
+
+export class OfflineCompositor {
+  private manager: CompositorManager;
+  private api: ApiClient;
+  private store: _liveCompositorInternals.InstanceContextStore;
+  private renderStarted: boolean = false;
+
+  public constructor(manager: CompositorManager) {
+    this.manager = manager;
+    this.api = new ApiClient(this.manager);
+    this.store = new _liveCompositorInternals.InstanceContextStore();
+  }
+
+  public async init(): Promise<void> {
+    this.checkNotStarted();
+    await this.manager.setupInstance({ aheadOfTimeProcessing: true });
+  }
+
+  public async render(request: RegisterOutput, durationMs: number) {
+    this.checkNotStarted();
+    this.renderStarted = true;
+
+    const output = new OfflineOutput(OFFLINE_OUTPUT_ID, request, this.api, this.store, durationMs);
+    const apiRequest = intoRegisterOutput(request, output.scene());
+    await this.api.registerOutput(OFFLINE_OUTPUT_ID, apiRequest);
+    await output.scheduleAllUpdates();
+
+    // at this point all scene update requests should already be delivered
+
+    await this.api.unregisterOutput(OFFLINE_OUTPUT_ID, { schedule_time_ms: durationMs });
+
+    const renderPromise = new Promise<void>((res, _rej) => {
+      this.manager.registerEventListener(rawEvent => {
+        const event = parseEvent(rawEvent);
+        if (
+          event &&
+          event.type === CompositorEventType.OUTPUT_DONE &&
+          event.outputId === OFFLINE_OUTPUT_ID
+        ) {
+          res();
+        }
+      });
+    });
+
+    await this.api.start();
+
+    await renderPromise;
+    output.outputShutdownStateStore.close();
+  }
+
+  public async registerInput(inputId: string, request: RegisterInput): Promise<object> {
+    this.checkNotStarted();
+    return this.store.runBlocking(async updateStore => {
+      const result = await this.api.registerInput(inputId, intoRegisterInput(request));
+      updateStore({ type: 'add_input', input: { inputId } });
+      return result;
+    });
+  }
+
+  public async registerShader(
+    shaderId: string,
+    request: Renderers.RegisterShader
+  ): Promise<object> {
+    this.checkNotStarted();
+    return this.api.registerShader(shaderId, request);
+  }
+
+  public async registerImage(imageId: string, request: Renderers.RegisterImage): Promise<object> {
+    this.checkNotStarted();
+    return this.api.registerImage(imageId, intoRegisterImage(request));
+  }
+
+  public async registerWebRenderer(
+    instanceId: string,
+    request: Renderers.RegisterWebRenderer
+  ): Promise<object> {
+    this.checkNotStarted();
+    return this.api.registerWebRenderer(instanceId, intoRegisterWebRenderer(request));
+  }
+
+  private checkNotStarted() {
+    if (this.renderStarted) {
+      throw new Error('Render was already started.');
+    }
+  }
+}

--- a/ts/@live-compositor/core/src/offline/output.ts
+++ b/ts/@live-compositor/core/src/offline/output.ts
@@ -1,0 +1,206 @@
+import type { Outputs } from 'live-compositor';
+import { _liveCompositorInternals, View } from 'live-compositor';
+import type React from 'react';
+import { createElement, useSyncExternalStore } from 'react';
+import type { ApiClient, Api } from '../api.js';
+import Renderer from '../renderer.js';
+import type { RegisterOutput } from '../api/output.js';
+import { intoAudioInputsConfiguration } from '../api/output.js';
+import { sleep } from '../utils.js';
+
+type AudioContext = _liveCompositorInternals.AudioContext;
+type OfflineTimeContext = _liveCompositorInternals.OfflineTimeContext;
+type InstanceContextStore = _liveCompositorInternals.InstanceContextStore;
+
+class OfflineOutput {
+  api: ApiClient;
+  outputId: string;
+  audioContext: AudioContext;
+  timeContext: OfflineTimeContext;
+  outputShutdownStateStore: OutputShutdownStateStore;
+  durationMs: number;
+  updateTracker: UpdateTracker = new UpdateTracker();
+
+  videoRenderer?: Renderer;
+  initialAudioConfig?: Outputs.AudioInputsConfiguration;
+
+  constructor(
+    outputId: string,
+    registerRequest: RegisterOutput,
+    api: ApiClient,
+    store: InstanceContextStore,
+    durationMs: number
+  ) {
+    this.api = api;
+    this.outputId = outputId;
+    this.outputShutdownStateStore = new OutputShutdownStateStore();
+    this.durationMs = durationMs;
+
+    const supportsAudio = 'audio' in registerRequest && !!registerRequest.audio;
+    if (supportsAudio) {
+      this.initialAudioConfig = registerRequest.audio!.initial ?? { inputs: [] };
+    }
+
+    const onUpdate = () => this.updateTracker.onUpdate();
+    this.audioContext = new _liveCompositorInternals.AudioContext(onUpdate, supportsAudio);
+    this.timeContext = new _liveCompositorInternals.OfflineTimeContext(onUpdate);
+
+    if (registerRequest.video) {
+      const rootElement = createElement(OutputRootComponent, {
+        instanceStore: store,
+        audioContext: this.audioContext,
+        timeContext: this.timeContext,
+        outputRoot: registerRequest.video.root,
+        outputShutdownStateStore: this.outputShutdownStateStore,
+      });
+
+      this.videoRenderer = new Renderer({
+        rootElement,
+        onUpdate,
+        idPrefix: `${outputId}-`,
+      });
+    }
+  }
+
+  public scene(): { video?: Api.Video; audio?: Api.Audio; schedule_time_ms: number } {
+    const audio = this.audioContext.getAudioConfig() ?? this.initialAudioConfig;
+    return {
+      video: this.videoRenderer && { root: this.videoRenderer.scene() },
+      audio: audio && intoAudioInputsConfiguration(audio),
+      schedule_time_ms: this.timeContext.timestampMs(),
+    };
+  }
+
+  public async scheduleAllUpdates(): Promise<void> {
+    while (this.timeContext.timestampMs() <= this.durationMs) {
+      while (true) {
+        await waitForBlockingTasks(this.timeContext);
+        await this.updateTracker.waitForRenderEnd();
+        if (!this.timeContext.isBlocked()) {
+          break;
+        }
+      }
+
+      const scene = this.scene();
+      await this.api.updateScene(this.outputId, scene);
+      this.timeContext.setNextTimestamp();
+    }
+
+    this.outputShutdownStateStore.close();
+  }
+}
+
+async function waitForBlockingTasks(offlineContext: OfflineTimeContext): Promise<void> {
+  while (offlineContext.isBlocked()) {
+    await sleep(100);
+  }
+}
+
+const MAX_NO_UPDATE_TIMEOUT_MS = 20;
+const MAX_RENDER_TIMEOUT_MS = 2000;
+
+/**
+ * Instance that tracks updates, this utils allows us to
+ * to monitor when last update happened in the react tree.
+ *
+ * If there were no updates for MAX_NO_UPDATE_TIMEOUT_MS or
+ * MAX_RENDER_TIMEOUT_MS already passed since we started rendering
+ * specific PTS then assume it's ready to grab a snapshot of a tree
+ */
+class UpdateTracker {
+  private promise: Promise<void> = new Promise(() => {});
+  private promiseRes: () => void = () => {};
+  private updateTimeout: number = -1;
+  private renderTimeout: number = -1;
+
+  constructor() {
+    this.promise = new Promise((res, _rej) => {
+      this.promiseRes = res;
+    });
+  }
+
+  public onUpdate() {
+    clearTimeout(this.updateTimeout);
+    this.updateTimeout = setTimeout(() => {
+      this.promiseRes();
+    }, MAX_NO_UPDATE_TIMEOUT_MS);
+  }
+
+  public async waitForRenderEnd(): Promise<void> {
+    this.promise = new Promise((res, _rej) => {
+      this.promiseRes = res;
+    });
+    clearTimeout(this.renderTimeout);
+    this.renderTimeout = setTimeout(() => {
+      console.warn(
+        "Render for a specific timestamp took too long, make sure you don't have infinite update loop."
+      );
+      this.promiseRes();
+    }, MAX_RENDER_TIMEOUT_MS);
+    await this.promise;
+    clearTimeout(this.renderTimeout);
+    clearTimeout(this.updateTimeout);
+  }
+}
+
+// External store to share shutdown information between React tree
+// and external code that is managing it.
+class OutputShutdownStateStore {
+  private shutdown: boolean = false;
+  private onChangeCallbacks: Set<() => void> = new Set();
+
+  public close() {
+    this.shutdown = true;
+    this.onChangeCallbacks.forEach(cb => cb());
+  }
+
+  // callback for useSyncExternalStore
+  public getSnapshot = (): boolean => {
+    return this.shutdown;
+  };
+
+  // callback for useSyncExternalStore
+  public subscribe = (onStoreChange: () => void): (() => void) => {
+    this.onChangeCallbacks.add(onStoreChange);
+    return () => {
+      this.onChangeCallbacks.delete(onStoreChange);
+    };
+  };
+}
+
+function OutputRootComponent({
+  outputRoot,
+  instanceStore,
+  timeContext,
+  audioContext,
+  outputShutdownStateStore,
+}: {
+  outputRoot: React.ReactElement;
+  instanceStore: InstanceContextStore;
+  timeContext: OfflineTimeContext;
+  audioContext: AudioContext;
+  outputShutdownStateStore: OutputShutdownStateStore;
+}) {
+  const shouldShutdown = useSyncExternalStore(
+    outputShutdownStateStore.subscribe,
+    outputShutdownStateStore.getSnapshot
+  );
+
+  if (shouldShutdown) {
+    // replace root with view to stop all the dynamic code
+    return createElement(View, {});
+  }
+
+  const reactCtx = {
+    instanceStore,
+    timeContext,
+    audioContext,
+  };
+  return createElement(
+    _liveCompositorInternals.LiveCompositorContext.Provider,
+    { value: reactCtx },
+    outputRoot
+  );
+}
+
+export default OfflineOutput;

--- a/ts/@live-compositor/core/src/renderer.ts
+++ b/ts/@live-compositor/core/src/renderer.ts
@@ -221,8 +221,16 @@ type RendererOptions = {
   idPrefix: string;
 };
 
+// docs
+interface FiberRootNode {
+  tag: number; // 0
+  containerInfo: Renderer;
+  pendingChildren: LiveCompositorHostComponent[];
+  current: any;
+}
+
 class Renderer {
-  private root: any;
+  public readonly root: FiberRootNode;
   public readonly onUpdate: () => void;
 
   constructor({ rootElement, onUpdate, idPrefix }: RendererOptions) {
@@ -246,13 +254,14 @@ class Renderer {
     // When resetAfterCommit is called `this.root.current` is not updated yet, so we need to rely
     // on `pendingChildren`. I'm not sure it is always populated, so there is a fallback to
     // `root.current`.
+
     const rootComponent = this.root.pendingChildren[0] ?? rootHostComponent(this.root.current);
     return rootComponent.scene();
   }
 }
 
 function rootHostComponent(root: any): LiveCompositorHostComponent {
-  console.error('No pendingChildren found, this might be an error');
+  console.error('No pendingChildren found, this might be an error.');
   let current = root;
   while (current) {
     if (current?.stateNode instanceof LiveCompositorHostComponent) {

--- a/ts/@live-compositor/core/tsconfig.cjs.json
+++ b/ts/@live-compositor/core/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2016",
+    "target": "es2017",
     "outDir": "cjs",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/ts/@live-compositor/node/src/index.ts
+++ b/ts/@live-compositor/node/src/index.ts
@@ -1,11 +1,20 @@
 import type { CompositorManager } from '@live-compositor/core';
-import { LiveCompositor as CoreLiveCompositor } from '@live-compositor/core';
+import {
+  LiveCompositor as CoreLiveCompositor,
+  OfflineCompositor as CoreOfflineCompositor,
+} from '@live-compositor/core';
 import LocallySpawnedInstance from './manager/locallySpawnedInstance';
 import ExistingInstance from './manager/existingInstance';
 
 export { LocallySpawnedInstance, ExistingInstance };
 
 export default class LiveCompositor extends CoreLiveCompositor {
+  constructor(manager?: CompositorManager) {
+    super(manager ?? LocallySpawnedInstance.defaultManager());
+  }
+}
+
+export class OfflineCompositor extends CoreOfflineCompositor {
   constructor(manager?: CompositorManager) {
     super(manager ?? LocallySpawnedInstance.defaultManager());
   }

--- a/ts/@live-compositor/node/src/manager/existingInstance.ts
+++ b/ts/@live-compositor/node/src/manager/existingInstance.ts
@@ -1,4 +1,4 @@
-import type { ApiRequest, CompositorManager } from '@live-compositor/core';
+import type { ApiRequest, CompositorManager, SetupInstanceOptions } from '@live-compositor/core';
 
 import { sendRequest } from '../fetch';
 import { retry, sleep } from '../utils';
@@ -28,7 +28,9 @@ class ExistingInstance implements CompositorManager {
     this.wsConnection = new WebSocketConnection(`${wsProtocol}://${this.ip}:${this.port}/ws`);
   }
 
-  public async setupInstance(): Promise<void> {
+  public async setupInstance(_opts: SetupInstanceOptions): Promise<void> {
+    // TODO: verify if options match
+    // https://github.com/software-mansion/live-compositor/issues/877
     await retry(async () => {
       await sleep(500);
       return await this.sendRequest({

--- a/ts/examples/node-examples/src/combine_mp4.tsx
+++ b/ts/examples/node-examples/src/combine_mp4.tsx
@@ -1,0 +1,90 @@
+import { OfflineCompositor } from '@live-compositor/node';
+import {
+  View,
+  Text,
+  Tiles,
+  Rescaler,
+  InputStream,
+  useCurrentTimestamp,
+  useAfterTimestamp,
+  Show,
+} from 'live-compositor';
+import { downloadAllAssets } from './utils';
+import path from 'path';
+import { useState } from 'react';
+
+function ExampleApp() {
+  return (
+    <Tiles transition={{ durationMs: 200 }}>
+      <InputTile inputId="input_1" />
+      <Show delayMs={2000}>
+        <InputTile inputId="input_2" />
+      </Show>
+      <Show timestampMs={{ start: 5000, end: 8000 }}>
+        <InputTile inputId="input_2" />
+      </Show>
+    </Tiles>
+  );
+}
+
+function InputTile({ inputId }: { inputId: string }) {
+  const currentTimestamp = useCurrentTimestamp();
+  const [mountTime, _setMountTime] = useState(() => currentTimestamp);
+  const afterDelay = useAfterTimestamp(mountTime + 1000);
+
+  const bottom = afterDelay ? 10 : 1080;
+  return (
+    <View>
+      <Rescaler>
+        <InputStream inputId={inputId} />
+      </Rescaler>
+      <View style={{ bottom, left: 10, height: 50 }} transition={{ durationMs: 1000 }}>
+        <Text
+          style={{ fontSize: 40, color: '#FF0000', lineHeight: 50, backgroundColor: '#FFFFFF88' }}>
+          Input ID: {inputId}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+async function run() {
+  await downloadAllAssets();
+  const compositor = new OfflineCompositor();
+  await compositor.init();
+
+  await compositor.registerInput('input_1', {
+    type: 'mp4',
+    serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
+    offsetMs: 0,
+    required: true,
+  });
+
+  await compositor.registerInput('input_2', {
+    type: 'mp4',
+    serverPath: path.join(__dirname, '../.assets/ElephantsDream.mp4'),
+    offsetMs: 0,
+    required: true,
+  });
+
+  await compositor.render(
+    {
+      type: 'mp4',
+      serverPath: path.join(__dirname, '../.assets/combing_mp4_output.mp4'),
+      video: {
+        encoder: {
+          type: 'ffmpeg_h264',
+          preset: 'ultrafast',
+        },
+        resolution: {
+          width: 1920,
+          height: 1080,
+        },
+        root: <ExampleApp />,
+      },
+    },
+    10000
+  );
+  process.exit(0);
+}
+void run();

--- a/ts/examples/node-examples/src/combine_mp4.tsx
+++ b/ts/examples/node-examples/src/combine_mp4.tsx
@@ -20,7 +20,7 @@ function ExampleApp() {
       <Show delayMs={2000}>
         <InputTile inputId="input_2" />
       </Show>
-      <Show timestampMs={{ start: 5000, end: 8000 }}>
+      <Show timeRangeMs={{ start: 5000, end: 8000 }}>
         <InputTile inputId="input_2" />
       </Show>
     </Tiles>

--- a/ts/examples/node-examples/src/concat_mp4.tsx
+++ b/ts/examples/node-examples/src/concat_mp4.tsx
@@ -1,5 +1,5 @@
 import { OfflineCompositor } from '@live-compositor/node';
-import { View, Text, Rescaler, InputStream, Slides, Slide } from 'live-compositor';
+import { View, Text, Rescaler, InputStream, SlideShow, Slide } from 'live-compositor';
 import { downloadAllAssets } from './utils';
 import path from 'path';
 import { useTimeLimitedComponent } from '../../../live-compositor/cjs/context/childrenLifetimeContext';
@@ -7,7 +7,7 @@ import { useTimeLimitedComponent } from '../../../live-compositor/cjs/context/ch
 function ExampleApp() {
   return (
     <View>
-      <Slides>
+      <SlideShow>
         <Slide>
           <Input inputId="input_1" endTimestamp={3_000} />
         </Slide>
@@ -17,7 +17,7 @@ function ExampleApp() {
         <Slide durationMs={3_000}>
           <Input inputId="input_1" endTimestamp={10_000} />
         </Slide>
-      </Slides>
+      </SlideShow>
     </View>
   );
 }

--- a/ts/examples/node-examples/src/concat_mp4.tsx
+++ b/ts/examples/node-examples/src/concat_mp4.tsx
@@ -1,0 +1,83 @@
+import { OfflineCompositor } from '@live-compositor/node';
+import { View, Text, Rescaler, InputStream, Slides, Slide } from 'live-compositor';
+import { downloadAllAssets } from './utils';
+import path from 'path';
+import { useTimeLimitedComponent } from '../../../live-compositor/cjs/context/childrenLifetimeContext';
+
+function ExampleApp() {
+  return (
+    <View>
+      <Slides>
+        <Slide>
+          <Input inputId="input_1" endTimestamp={3_000} />
+        </Slide>
+        <Slide>
+          <Input inputId="input_2" endTimestamp={6_000} />
+        </Slide>
+        <Slide durationMs={3_000}>
+          <Input inputId="input_1" endTimestamp={10_000} />
+        </Slide>
+      </Slides>
+    </View>
+  );
+}
+
+function Input({ inputId, endTimestamp }: { inputId: string; endTimestamp: number }) {
+  // Temporary, useTimeLimitedComponent is an internal hook, InputStream component will rely
+  // on the mp4 length returned from the compositor
+  useTimeLimitedComponent(endTimestamp);
+  return (
+    <View>
+      <Rescaler>
+        <InputStream inputId={inputId} />
+      </Rescaler>
+      <View style={{ bottom: 10, left: 10, height: 50 }}>
+        <Text
+          style={{ fontSize: 40, color: '#FF0000', lineHeight: 50, backgroundColor: '#FFFFFF88' }}>
+          Input ID: {inputId}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+async function run() {
+  await downloadAllAssets();
+  const compositor = new OfflineCompositor();
+  await compositor.init();
+
+  await compositor.registerInput('input_1', {
+    type: 'mp4',
+    serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
+    offsetMs: 0,
+    required: true,
+  });
+
+  await compositor.registerInput('input_2', {
+    type: 'mp4',
+    serverPath: path.join(__dirname, '../.assets/ElephantsDream.mp4'),
+    offsetMs: 5000,
+    required: true,
+  });
+
+  await compositor.render(
+    {
+      type: 'mp4',
+      serverPath: path.join(__dirname, '../.assets/concat_mp4_output.mp4'),
+      video: {
+        encoder: {
+          type: 'ffmpeg_h264',
+          preset: 'ultrafast',
+        },
+        resolution: {
+          width: 1920,
+          height: 1080,
+        },
+        root: <ExampleApp />,
+      },
+    },
+    10000
+  );
+  process.exit(0);
+}
+void run();

--- a/ts/live-compositor/src/components/Show.ts
+++ b/ts/live-compositor/src/components/Show.ts
@@ -5,22 +5,22 @@ import { LiveCompositorContext } from '../context/index.js';
 import { useContext, useEffect, useState } from 'react';
 
 export type ShowProps = {
-  timestampMs?: { start?: number; end?: number };
+  timeRangeMs?: { start?: number; end?: number };
   delayMs?: number;
   children?: React.ReactNode;
 };
 
 function Show(props: ShowProps) {
-  if ('delayMs' in props && props.timestampMs) {
+  if ('delayMs' in props && props.timeRangeMs) {
     throw new Error('"delayMs" and "timestamp" props can\'t be specified at the same time.');
   }
-  if (props.timestampMs && !props.timestampMs.start && !props.timestampMs.end) {
+  if (props.timeRangeMs && !props.timeRangeMs.start && !props.timeRangeMs.end) {
     throw new Error('"timestampMs" prop needs to define at least one value "start" or "end".');
   }
   const ctx = useContext(LiveCompositorContext);
   const [mountTimestampMs, setStart] = useState<number>(() => ctx.timeContext.timestampMs());
-  const afterStart = useAfterTimestamp(props.timestampMs?.start ?? 0);
-  const afterEnd = useAfterTimestamp(props.timestampMs?.end ?? Infinity);
+  const afterStart = useAfterTimestamp(props.timeRangeMs?.start ?? 0);
+  const afterEnd = useAfterTimestamp(props.timeRangeMs?.end ?? Infinity);
   const isAfterDelay = useAfterTimestamp(mountTimestampMs + (props.delayMs ?? 0));
 
   useEffect(() => {
@@ -29,7 +29,7 @@ function Show(props: ShowProps) {
 
   if (props.delayMs !== undefined && isAfterDelay) {
     return props.children;
-  } else if (props.timestampMs && afterStart && !afterEnd) {
+  } else if (props.timeRangeMs && afterStart && !afterEnd) {
     return props.children;
   } else {
     return null;

--- a/ts/live-compositor/src/components/Show.ts
+++ b/ts/live-compositor/src/components/Show.ts
@@ -1,0 +1,39 @@
+import type React from 'react';
+
+import { useAfterTimestamp } from '../hooks.js';
+import { LiveCompositorContext } from '../context/index.js';
+import { useContext, useEffect, useState } from 'react';
+
+export type ShowProps = {
+  timestampMs?: { start?: number; end?: number };
+  delayMs?: number;
+  children?: React.ReactNode;
+};
+
+function Show(props: ShowProps) {
+  if ('delayMs' in props && props.timestampMs) {
+    throw new Error('"delayMs" and "timestamp" props can\'t be specified at the same time.');
+  }
+  if (props.timestampMs && !props.timestampMs.start && !props.timestampMs.end) {
+    throw new Error('"timestampMs" prop needs to define at least one value "start" or "end".');
+  }
+  const ctx = useContext(LiveCompositorContext);
+  const [mountTimestampMs, setStart] = useState<number>(() => ctx.timeContext.timestampMs());
+  const afterStart = useAfterTimestamp(props.timestampMs?.start ?? 0);
+  const afterEnd = useAfterTimestamp(props.timestampMs?.end ?? Infinity);
+  const isAfterDelay = useAfterTimestamp(mountTimestampMs + (props.delayMs ?? 0));
+
+  useEffect(() => {
+    setStart(ctx.timeContext.timestampMs());
+  }, []);
+
+  if (props.delayMs !== undefined && isAfterDelay) {
+    return props.children;
+  } else if (props.timestampMs && afterStart && !afterEnd) {
+    return props.children;
+  } else {
+    return null;
+  }
+}
+
+export default Show;

--- a/ts/live-compositor/src/components/SlideShow.ts
+++ b/ts/live-compositor/src/components/SlideShow.ts
@@ -19,11 +19,11 @@ export type SlideProps = {
   children?: React.ReactNode;
 };
 
-export type SlidesProps = {
+export type SlideShowProps = {
   children: React.ReactNode;
 };
 
-export function Slides(props: SlidesProps) {
+export function SlideShow(props: SlideShowProps) {
   const prevChildrenRef = useRef<React.ReactNode>();
   const [childIndex, setChildIndex] = useState<number>(0);
 
@@ -31,7 +31,7 @@ export function Slides(props: SlidesProps) {
 
   for (const slide of childrenArray) {
     if ((slide as ReactElement).type !== Slide) {
-      throw new Error('Slides component only accepts Slides as children');
+      throw new Error('SlideShow component only accepts <Slide /> as children');
     }
   }
 

--- a/ts/live-compositor/src/context/audioOutputContext.ts
+++ b/ts/live-compositor/src/context/audioOutputContext.ts
@@ -11,7 +11,7 @@ export type AudioInputConfig = {
   volumeComponents: ContextAudioOptions[];
 };
 
-export class OutputContext {
+export class AudioContext {
   private audioMixerConfig?: AudioConfig;
   private onChange: () => void;
 

--- a/ts/live-compositor/src/context/childrenLifetimeContext.ts
+++ b/ts/live-compositor/src/context/childrenLifetimeContext.ts
@@ -1,0 +1,50 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { useAfterTimestamp } from '../hooks.js';
+
+export class ChildrenLifetimeContext {
+  private timestamps: Array<{ end: number }> = [];
+  private onTimestampRemoved: () => void;
+
+  constructor(onSlideEnd: () => void) {
+    this.onTimestampRemoved = onSlideEnd;
+  }
+
+  public addEndTimestamp(ts: { end: number }) {
+    this.timestamps.push(ts);
+  }
+
+  public removeEndTimestamp(ts: { end: number }) {
+    this.timestamps = this.timestamps.filter(timestamp => ts !== timestamp);
+    this.onTimestampRemoved();
+  }
+
+  public isDone(): boolean {
+    return this.timestamps.length === 0;
+  }
+}
+
+export const ChildrenLifetimeContextType = createContext(new ChildrenLifetimeContext(() => {}));
+
+/**
+ * Internal helper hook that can be use inside other components to propagate
+ * their duration/lifetime to the parents.
+ */
+export function useTimeLimitedComponent(timestamp: number) {
+  const childrenLifetimeContext = useContext(ChildrenLifetimeContextType);
+  const afterTimestamp = useAfterTimestamp(timestamp);
+  const [timestampObject, setTimestampObject] = useState<{ end: number }>();
+  useEffect(() => {
+    let tsObject = { end: timestamp };
+    setTimestampObject(tsObject);
+    childrenLifetimeContext.addEndTimestamp(tsObject);
+    return () => {
+      childrenLifetimeContext.removeEndTimestamp(tsObject);
+    };
+  }, [timestamp]);
+
+  useEffect(() => {
+    if (timestampObject && afterTimestamp) {
+      childrenLifetimeContext.removeEndTimestamp(timestampObject);
+    }
+  }, [afterTimestamp]);
+}

--- a/ts/live-compositor/src/context/index.ts
+++ b/ts/live-compositor/src/context/index.ts
@@ -1,17 +1,20 @@
 import { createContext } from 'react';
 import { InstanceContextStore } from './instanceContextStore.js';
-import { OutputContext } from './outputContext.js';
+import { AudioContext } from './audioOutputContext.js';
+import type { TimeContext } from './timeContext.js';
+import { LiveTimeContext } from './timeContext.js';
 
-type CompositorOutputContext = {
+export type CompositorOutputContext = {
   // global store for the entire LiveCompositor instance
   instanceStore: InstanceContextStore;
-  // state specific to the current output
-  outputCtx: OutputContext;
+  // Audio mixer configuration
+  audioContext: AudioContext;
+  // Time tracking and handling for blocking tasks
+  timeContext: TimeContext;
 };
 
 export const LiveCompositorContext = createContext<CompositorOutputContext>({
   instanceStore: new InstanceContextStore(),
-  outputCtx: new OutputContext(() => {}, false),
+  audioContext: new AudioContext(() => {}, false),
+  timeContext: new LiveTimeContext(),
 });
-
-export { InstanceContextStore, OutputContext };

--- a/ts/live-compositor/src/context/timeContext.ts
+++ b/ts/live-compositor/src/context/timeContext.ts
@@ -1,0 +1,136 @@
+export interface BlockingTask {
+  done(): void;
+}
+
+export interface TimeContext {
+  timestampMs(): number;
+
+  addTimestamp(timestamp: TimestampObject): void;
+  removeTimestamp(timestamp: TimestampObject): void;
+
+  getSnapshot: () => number;
+  subscribe: (onStoreChange: () => void) => () => void;
+}
+
+// Wrapped in object, so we can compare it by reference.
+type TimestampObject = { timestamp: number };
+
+export class OfflineTimeContext {
+  private timestamps: TimestampObject[];
+  private tasks: BlockingTask[];
+  private onChange: () => void;
+  private currentTimestamp: number = 0;
+  private onChangeCallbacks: Set<() => void> = new Set();
+
+  constructor(onChange: () => void) {
+    this.onChange = onChange;
+    this.tasks = [];
+    this.timestamps = [];
+  }
+
+  public timestampMs(): number {
+    return this.currentTimestamp;
+  }
+
+  public isBlocked(): boolean {
+    return this.tasks.length !== 0;
+  }
+
+  public newBlockingTask(): BlockingTask {
+    const task: BlockingTask = {} as any;
+    task.done = () => {
+      this.tasks = this.tasks.filter(t => t !== task);
+      if (this.tasks.length === 0) {
+        this.onChange();
+      }
+    };
+    this.tasks.push(task);
+    return task;
+  }
+
+  public addTimestamp(timestamp: TimestampObject) {
+    this.timestamps.push(timestamp);
+  }
+
+  public removeTimestamp(timestamp: TimestampObject) {
+    this.timestamps = this.timestamps.filter(t => timestamp !== t);
+  }
+
+  public setNextTimestamp() {
+    const next = this.timestamps.reduce(
+      (acc, value) =>
+        value.timestamp < acc.timestamp && value.timestamp > this.currentTimestamp ? value : acc,
+      { timestamp: Infinity }
+    );
+    this.currentTimestamp = next.timestamp;
+    for (const cb of this.onChangeCallbacks) {
+      cb();
+    }
+  }
+
+  // callback for useSyncExternalStore
+  public getSnapshot = (): number => {
+    return this.currentTimestamp;
+  };
+
+  // callback for useSyncExternalStore
+  public subscribe = (onStoreChange: () => void): (() => void) => {
+    this.onChangeCallbacks.add(onStoreChange);
+    return () => {
+      this.onChangeCallbacks.delete(onStoreChange);
+    };
+  };
+}
+
+export class LiveTimeContext {
+  private startTimestampMs: number = 0;
+  private timestamps: Array<{ timestamp: TimestampObject; timeout?: number }>;
+  private onChangeCallbacks: Set<() => void> = new Set();
+
+  constructor() {
+    this.timestamps = [];
+  }
+
+  public timestampMs(): number {
+    return this.startTimestampMs ? Date.now() - this.startTimestampMs : 0;
+  }
+
+  public initClock(timestamp: number) {
+    this.startTimestampMs = timestamp;
+  }
+
+  public addTimestamp(timestamp: TimestampObject) {
+    this.timestamps.push({ timestamp, timeout: this.scheduleChangeNotification(timestamp) });
+  }
+
+  public removeTimestamp(timestamp: TimestampObject) {
+    const removed = this.timestamps.filter(t => timestamp === t.timestamp);
+    this.timestamps = this.timestamps.filter(t => timestamp !== t.timestamp);
+    removed.forEach(ts => clearTimeout(ts.timeout));
+  }
+
+  private scheduleChangeNotification(timestamp: TimestampObject): number | undefined {
+    const timeLeft = timestamp.timestamp - this.timestampMs();
+    if (timeLeft < 0) {
+      return;
+    }
+    return setTimeout(() => {
+      for (const cb of this.onChangeCallbacks) {
+        cb();
+      }
+    }, timeLeft + 100);
+  }
+
+  // callback for useSyncExternalStore
+  public getSnapshot = (): number => {
+    return this.timestampMs();
+  };
+
+  // callback for useSyncExternalStore
+  public subscribe = (onStoreChange: () => void): (() => void) => {
+    this.onChangeCallbacks.add(onStoreChange);
+    return () => {
+      this.onChangeCallbacks.delete(onStoreChange);
+    };
+  };
+}

--- a/ts/live-compositor/src/hooks.ts
+++ b/ts/live-compositor/src/hooks.ts
@@ -1,8 +1,11 @@
-import { useContext, useEffect, useSyncExternalStore } from 'react';
+import { useContext, useEffect, useState, useSyncExternalStore } from 'react';
 
 import type * as Api from './api.js';
+import type { CompositorOutputContext } from './context/index.js';
 import { LiveCompositorContext } from './context/index.js';
 import type { InputStreamInfo } from './context/instanceContextStore.js';
+import type { BlockingTask } from './context/timeContext.js';
+import { OfflineTimeContext } from './context/timeContext.js';
 
 export function useInputStreams(): Record<Api.InputId, InputStreamInfo> {
   const ctx = useContext(LiveCompositorContext);
@@ -26,9 +29,89 @@ export function useAudioInput(inputId: Api.InputId, audioOptions: AudioOptions) 
 
   useEffect(() => {
     const options = { ...audioOptions };
-    ctx.outputCtx.addInputAudioComponent(inputId, options);
+    ctx.audioContext.addInputAudioComponent(inputId, options);
     return () => {
-      ctx.outputCtx.removeInputAudioComponent(inputId, options);
+      ctx.audioContext.removeInputAudioComponent(inputId, options);
     };
   }, [audioOptions]);
+}
+
+/**
+ *  Returns current timestamp relative to `LiveCompositor.start()`.
+ *
+ *  Not recommended for live processing. It triggers re-renders only for specific timestamps
+ *  that are registered with `useAfterTimestamp` hook(that includes components like Slide/Show).
+ */
+export function useCurrentTimestamp(): number {
+  const ctx = useContext(LiveCompositorContext);
+  const timeContext = ctx.timeContext;
+  useSyncExternalStore(timeContext.subscribe, timeContext.getSnapshot);
+  // Value from useSyncExternalStore is the same as TimeContext.timestampMs for
+  // offline processing, but for live `timestampMs` should be up to date.
+  return timeContext.timestampMs();
+}
+
+/**
+ * Hook that allows you to trigger updates after specific timestamp. Primary useful for
+ * offline processing.
+ */
+export function useAfterTimestamp(timestamp: number): boolean {
+  const ctx = useContext(LiveCompositorContext);
+  const currentTimestamp = useCurrentTimestamp();
+
+  useEffect(() => {
+    if (timestamp === Infinity) {
+      return;
+    }
+    const tsObject = { timestamp };
+    ctx.timeContext.addTimestamp(tsObject);
+    return () => {
+      ctx.timeContext.removeTimestamp(tsObject);
+    };
+  }, [timestamp]);
+
+  if (ctx.timeContext) {
+    return currentTimestamp >= timestamp;
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Create task that will stop rendering when compositor runs in offline mode.
+ *
+ * `task.done()` needs to be called when async action is finished, otherwise rendering will block indefinitely.
+ */
+export function newBlockingTask(ctx: CompositorOutputContext): BlockingTask {
+  if (ctx.timeContext instanceof OfflineTimeContext) {
+    return ctx.timeContext.newBlockingTask();
+  } else {
+    return { done: () => null };
+  }
+}
+
+/**
+ *  Run async function and return its result after Promise resolves.
+ *
+ *  For offline processing it additionally ensures that rendering for that
+ *  timestamp  will block until all blocking tasks are done.
+ */
+export function useBlockingTask<T>(fn: () => Promise<T>): T | undefined {
+  const ctx = useContext(LiveCompositorContext);
+  const [result, setResult] = useState<T | undefined>(undefined);
+  useEffect(() => {
+    const task = newBlockingTask(ctx);
+    void (async () => {
+      try {
+        setResult(await fn());
+      } finally {
+        task.done();
+      }
+    })();
+    return () => {
+      task.done();
+    };
+  }, []);
+
+  return result;
 }

--- a/ts/live-compositor/src/index.ts
+++ b/ts/live-compositor/src/index.ts
@@ -7,8 +7,16 @@ import WebView, { WebViewProps } from './components/WebView.js';
 import Shader, { ShaderParam, ShaderParamStructField, ShaderProps } from './components/Shader.js';
 import Tiles, { TilesProps } from './components/Tiles.js';
 import { EasingFunction, Transition } from './components/common.js';
-import { useAudioInput, useInputStreams } from './hooks.js';
+import {
+  useAudioInput,
+  useInputStreams,
+  useAfterTimestamp,
+  useBlockingTask,
+  useCurrentTimestamp,
+} from './hooks.js';
 import { CompositorEvent, CompositorEventType } from './types/events.js';
+import Show, { ShowProps } from './components/Show.js';
+import { Slides, Slide, SlideProps, SlidesProps } from './components/Slides.js';
 
 export { RegisterRtpInput, RegisterMp4Input } from './types/registerInput.js';
 export {
@@ -40,10 +48,16 @@ export {
   ShaderProps,
   Tiles,
   TilesProps,
+  Show,
+  ShowProps,
+  Slide,
+  SlideProps,
+  Slides,
+  SlidesProps,
 };
 
 export { CompositorEvent, CompositorEventType };
 
-export { useInputStreams, useAudioInput };
+export { useInputStreams, useAudioInput, useBlockingTask, useAfterTimestamp, useCurrentTimestamp };
 
 export { ShaderParam, ShaderParamStructField, EasingFunction, Transition };

--- a/ts/live-compositor/src/index.ts
+++ b/ts/live-compositor/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from './hooks.js';
 import { CompositorEvent, CompositorEventType } from './types/events.js';
 import Show, { ShowProps } from './components/Show.js';
-import { Slides, Slide, SlideProps, SlidesProps } from './components/Slides.js';
+import { SlideShow, Slide, SlideProps, SlideShowProps } from './components/SlideShow.js';
 
 export { RegisterRtpInput, RegisterMp4Input } from './types/registerInput.js';
 export {
@@ -52,8 +52,8 @@ export {
   ShowProps,
   Slide,
   SlideProps,
-  Slides,
-  SlidesProps,
+  SlideShow,
+  SlideShowProps,
 };
 
 export { CompositorEvent, CompositorEventType };

--- a/ts/live-compositor/src/internal.ts
+++ b/ts/live-compositor/src/internal.ts
@@ -1,4 +1,7 @@
 // Internal logic used by `@live-compositor/core`, do not use directly
 
-export { InstanceContextStore, OutputContext, LiveCompositorContext } from './context/index.js';
+export { LiveCompositorContext } from './context/index.js';
+export { OfflineTimeContext, LiveTimeContext, TimeContext } from './context/timeContext.js';
+export { AudioContext } from './context/audioOutputContext.js';
+export { InstanceContextStore } from './context/instanceContextStore.js';
 export { SceneBuilder, SceneComponent } from './component.js';

--- a/ts/package.json
+++ b/ts/package.json
@@ -29,6 +29,7 @@
     "globals": "^15.9.0",
     "json-schema-to-typescript": "^15.0.1",
     "prettier": "^3.3.3",
+    "rimraf": "^6.0.1",
     "typescript": "5.5.3"
   },
   "overrides": {

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
       typescript:
         specifier: 5.5.3
         version: 5.5.3
@@ -1558,6 +1561,11 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@11.0.0:
+    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1746,6 +1754,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.0.2:
+    resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
+    engines: {node: 20 || >=22}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1815,6 +1827,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.0.2:
+    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1855,6 +1871,10 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2009,6 +2029,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
+
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
@@ -2128,6 +2152,11 @@ packages:
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  rimraf@6.0.1:
+    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rollup-plugin-copy@3.5.0:
@@ -3611,7 +3640,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0))(eslint@9.15.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -3624,7 +3653,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0))(eslint@9.15.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3646,7 +3675,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-plugin-import@2.31.0)(eslint@9.15.0))(eslint@9.15.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.15.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -3935,6 +3964,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.0.0:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 4.0.2
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4119,6 +4157,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.0.2:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4186,6 +4228,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.0.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4216,6 +4260,10 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
 
   minimatch@3.1.2:
     dependencies:
@@ -4350,6 +4398,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.0.2
+      minipass: 7.1.2
+
   path-to-regexp@0.1.10: {}
 
   path-type@4.0.0: {}
@@ -4453,6 +4506,11 @@ snapshots:
   rimraf@5.0.10:
     dependencies:
       glob: 10.4.5
+
+  rimraf@6.0.1:
+    dependencies:
+      glob: 11.0.0
+      package-json-from-dist: 1.0.1
 
   rollup-plugin-copy@3.5.0:
     dependencies:


### PR DESCRIPTION
### Api changes

- Add `Slides`/`Slide` components
- Add `Show` component
- Add the `useAfterTimestamp` hook (internally used by `Show`)
- Add `useCurrentTimestamp` returns the current timestamp (does not trigger re-render for every time change)
  - Alternative 1:  Add a hook that returns a function that returns a timestamp
  - Alternative 2: Add a hook that returns some context object that has a method that returns a timestamp
  - Alterantive 3: Do not expose it, but instead make `useAfterTimestamp` return the current timestamp (and maybe change name of that hook)
- Add `useBlockingTask` hook
  - For live cases run the async function on mount. Hook returns result if promise resolved or undefined otherwise
    - Similiar to https://react.dev/reference/react/use
  - For offline cases it blocks rendering until promise resolves and returns the result after.
- Keep `newBlockingTask` function prrivate (internal implementation of `useBlockingTask`)
  - When it would be usfull as public API?
    - It could be useful if you want to implement something more advanced than use useBlockingTask, e.g. instead of running on mount it would rerun on specific props changes, or it should trigger after some PTS
  - Alternative 1: Make that function public and add some hook that returns `TimeContext` object. (newBlockingTask needs the context as argument)
  - Alternative 2: Add hook e.g. `useBlockingTaskBuilder` that returns a function to start a new blocking task.
- Temporarily make public `useTimeLimitedComponent`. 
  - That hook is intended to be private after we start using it in `InputStream` or `Mp4` components. It is public for now, so we can write some examples and test internalls.
  - Alternative 1: Make that hook public so users can write their own components with a duration.

### TODO in follow up

- useInputStream will return correct states for offline processing based on offset and calculated duration.

```tsx
function ExampleAppWithMultipleScreens() {
  return (
    <>
      <Show timestampMS={{ end: 3000 }}>
        <SomeComponent description="show from the beginning until 3 second" />
      </Show>
      <Show timestampMs={{ start: 3000, end: 6000 }}>
        <SomeComponent description="show between 3s and 6s />
      </Show>
      <Show delayMs={3000}>
        <SomeComponent description="3 seconds after mount" />
      </Show>
    </>
  );
}
```

```tsx
function ExampleApp() {
  return (
    <View>
      <Slides>
        <Slide>
          <SomeComponent description="duration based on components inside Input" />
        </Slide>
        <Slide>
          <SomeComponent description="duration based on components inside Input" />
        </Slide>
        <Slide durationMs={3_000}>
          <SomeComponent  description="duration 3 seconds, ignore components" />
        </Slide>
      </Slides>
    </View>
  );
}
```

```tsx
function ExampleAppWithBlockingTask() {
  const text = useBlockingTask(async function() {
     const response = await fetch("https://some/data")
     return await response.text()
  });
  return (
    <View>
      <Text>{text}</Text>
    </View>
  );
}
```

Currently, there are no components that support automatic slide change. I'm planning to add
- Support for InputStream if it is mp4 to set it based on it's duration
- New Mp4 component that is basically InputStream but does not require registration
- (maybe) some fake component that does not render to anything but if it is inserted in scene it is forcing some duration