### PR TITLE
Download CEF binaries to `~/.cache`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "anyhow",
  "bindgen 0.66.1",
  "cmake",
+ "dirs",
  "fs_extra",
  "reqwest",
 ]
@@ -1065,6 +1066,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2692,6 +2714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "opus"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,6 +3080,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/compositor_chromium/chromium_sys/Cargo.toml
+++ b/compositor_chromium/chromium_sys/Cargo.toml
@@ -12,5 +12,6 @@ license = "BUSL-1.1"
 anyhow = "1.0.72"
 bindgen = "0.66.1"
 cmake = "0.1.50"
+dirs = "5.0.1"
 fs_extra = "1.3.0"
 reqwest = { workspace = true }

--- a/compositor_chromium/chromium_sys/build.rs
+++ b/compositor_chromium/chromium_sys/build.rs
@@ -14,9 +14,7 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed=CEF_ROOT");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    let cache_dir = PathBuf::from(env::var("HOME")?)
-        .join(".cache")
-        .join("live-compositor");
+    let cache_dir = dirs::cache_dir().unwrap().join("live-compositor");
     let cef_root = env::var("CEF_ROOT")
         .map(PathBuf::from)
         .unwrap_or(cache_dir.join("cef_root"));

--- a/compositor_chromium/chromium_sys/build.rs
+++ b/compositor_chromium/chromium_sys/build.rs
@@ -14,9 +14,12 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed=CEF_ROOT");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let cache_dir = PathBuf::from(env::var("HOME")?)
+        .join(".cache")
+        .join("live-compositor");
     let cef_root = env::var("CEF_ROOT")
         .map(PathBuf::from)
-        .unwrap_or(out_dir.join("cef_root"));
+        .unwrap_or(cache_dir.join("cef_root"));
 
     if !cef_root.exists() {
         for i in 0..5 {
@@ -157,9 +160,9 @@ fn download_cef(cef_root_path: &Path) -> Result<()> {
 
     let archive_name = "cef.tar.bz2";
     let content = resp.bytes()?;
-    fs::write(download_path.join(archive_name), content)?;
 
     fs::create_dir_all(cef_root_path)?;
+    fs::write(download_path.join(archive_name), content)?;
 
     let tar_status = Command::new("tar")
         .args([


### PR DESCRIPTION
Most of the CEF build time is spent on actually downloading CEF itself which happens every time `OUT_DIR` changes. I moved the default `cef_root` to `~/.cache` which helps with the recompilation a lot (less than 1s).