### PR TITLE
Use `<Mp4 />` without registration

### DIFF
--- a/ts/@live-compositor/core/src/api.ts
+++ b/ts/@live-compositor/core/src/api.ts
@@ -1,7 +1,7 @@
 import { Api } from 'live-compositor';
 import type { CompositorManager } from './compositorManager.js';
 import type { RegisterOutputRequest } from './api/output.js';
-import type { RegisterInputRequest } from './api/input.js';
+import { inputRefIntoRawId, type InputRef, type RegisterInputRequest } from './api/input.js';
 
 export { Api };
 
@@ -51,21 +51,24 @@ export class ApiClient {
   }
 
   public async registerInput(
-    inputId: string,
+    inputId: InputRef,
     request: RegisterInputRequest
   ): Promise<RegisterInputResponse> {
     return this.serverManager.sendRequest({
       method: 'POST',
-      route: `/api/input/${encodeURIComponent(inputId)}/register`,
+      route: `/api/input/${encodeURIComponent(inputRefIntoRawId(inputId))}/register`,
       body: request,
     });
   }
 
-  public async unregisterInput(inputId: string): Promise<object> {
+  public async unregisterInput(
+    inputId: InputRef,
+    body: { schedule_time_ms?: number }
+  ): Promise<object> {
     return this.serverManager.sendRequest({
       method: 'POST',
-      route: `/api/input/${encodeURIComponent(inputId)}/unregister`,
-      body: {},
+      route: `/api/input/${encodeURIComponent(inputRefIntoRawId(inputId))}/unregister`,
+      body,
     });
   }
 

--- a/ts/@live-compositor/core/src/api.ts
+++ b/ts/@live-compositor/core/src/api.ts
@@ -11,6 +11,11 @@ export type ApiRequest = {
   body?: object;
 };
 
+export type RegisterInputResponse = {
+  video_duration_ms?: number;
+  audio_duration_ms?: number;
+};
+
 export class ApiClient {
   private serverManager: CompositorManager;
 
@@ -45,7 +50,10 @@ export class ApiClient {
     });
   }
 
-  public async registerInput(inputId: string, request: RegisterInputRequest): Promise<object> {
+  public async registerInput(
+    inputId: string,
+    request: RegisterInputRequest
+  ): Promise<RegisterInputResponse> {
     return this.serverManager.sendRequest({
       method: 'POST',
       route: `/api/input/${encodeURIComponent(inputId)}/register`,

--- a/ts/@live-compositor/core/src/api/input.ts
+++ b/ts/@live-compositor/core/src/api/input.ts
@@ -1,7 +1,12 @@
 import type { Api } from '../api.js';
 import type { RegisterMp4Input, RegisterRtpInput, Inputs } from 'live-compositor';
+import { _liveCompositorInternals } from 'live-compositor';
 
 export type RegisterInputRequest = Api.RegisterInput;
+
+export type InputRef = _liveCompositorInternals.InputRef;
+export const inputRefIntoRawId = _liveCompositorInternals.inputRefIntoRawId;
+export const parseInputRef = _liveCompositorInternals.parseInputRef;
 
 export type RegisterInput =
   | ({ type: 'rtp_stream' } & RegisterRtpInput)

--- a/ts/@live-compositor/core/src/api/output.ts
+++ b/ts/@live-compositor/core/src/api/output.ts
@@ -4,7 +4,9 @@ import type {
   RegisterRtpOutput,
   RegisterMp4Output,
   RegisterCanvasOutput,
+  _liveCompositorInternals,
 } from 'live-compositor';
+import { inputRefIntoRawId } from './input.js';
 
 export type RegisterOutputRequest = Api.RegisterOutput | RegisterCanvasOutputRequest;
 
@@ -145,10 +147,12 @@ function intoMp4AudioEncoderOptions(
   };
 }
 
-export function intoAudioInputsConfiguration(audio: Outputs.AudioInputsConfiguration): Api.Audio {
+export function intoAudioInputsConfiguration(
+  inputs: _liveCompositorInternals.AudioConfig
+): Api.Audio {
   return {
-    inputs: audio.inputs.map(input => ({
-      input_id: input.inputId,
+    inputs: inputs.map(input => ({
+      input_id: inputRefIntoRawId(input.inputRef),
       volume: input.volume,
     })),
   };

--- a/ts/@live-compositor/core/src/event.ts
+++ b/ts/@live-compositor/core/src/event.ts
@@ -1,9 +1,9 @@
 import type { _liveCompositorInternals, CompositorEvent } from 'live-compositor';
 import { CompositorEventType } from 'live-compositor';
 
-type InstanceContextStore = _liveCompositorInternals.InstanceContextStore;
+type LiveInstanceContextStore = _liveCompositorInternals.LiveInstanceContextStore;
 
-export function onCompositorEvent(store: InstanceContextStore, rawEvent: unknown) {
+export function onCompositorEvent(store: LiveInstanceContextStore, rawEvent: unknown) {
   const event = parseEvent(rawEvent);
   if (!event) {
     return;

--- a/ts/@live-compositor/core/src/event.ts
+++ b/ts/@live-compositor/core/src/event.ts
@@ -1,44 +1,8 @@
-import type { _liveCompositorInternals, CompositorEvent } from 'live-compositor';
-import { CompositorEventType } from 'live-compositor';
+import { _liveCompositorInternals } from 'live-compositor';
+import { parseInputRef } from './api/input.js';
 
-type LiveInstanceContextStore = _liveCompositorInternals.LiveInstanceContextStore;
-
-export function onCompositorEvent(store: LiveInstanceContextStore, rawEvent: unknown) {
-  const event = parseEvent(rawEvent);
-  if (!event) {
-    return;
-  } else if (event.type === CompositorEventType.VIDEO_INPUT_DELIVERED) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, videoState: 'ready' },
-    });
-  } else if (event.type === CompositorEventType.VIDEO_INPUT_PLAYING) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, videoState: 'playing' },
-    });
-  } else if (event.type === CompositorEventType.VIDEO_INPUT_EOS) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, videoState: 'finished' },
-    });
-  } else if (event.type === CompositorEventType.AUDIO_INPUT_DELIVERED) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, audioState: 'ready' },
-    });
-  } else if (event.type === CompositorEventType.AUDIO_INPUT_PLAYING) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, audioState: 'playing' },
-    });
-  } else if (event.type === CompositorEventType.AUDIO_INPUT_EOS) {
-    store.dispatchUpdate({
-      type: 'update_input',
-      input: { inputId: event.inputId, audioState: 'finished' },
-    });
-  }
-}
+export type CompositorEvent = _liveCompositorInternals.CompositorEvent;
+export const CompositorEventType = _liveCompositorInternals.CompositorEventType;
 
 export function parseEvent(event: any): CompositorEvent | null {
   if (!event.type) {
@@ -54,7 +18,7 @@ export function parseEvent(event: any): CompositorEvent | null {
       CompositorEventType.AUDIO_INPUT_EOS,
     ].includes(event.type)
   ) {
-    return { type: event.type, inputId: event.input_id };
+    return { type: event.type, inputRef: parseInputRef(event.input_id) };
   } else if (CompositorEventType.OUTPUT_DONE === event.type) {
     return { type: event.type, outputId: event.output_id };
   } else {

--- a/ts/@live-compositor/core/src/live/compositor.ts
+++ b/ts/@live-compositor/core/src/live/compositor.ts
@@ -7,29 +7,35 @@ import type { RegisterOutput } from '../api/output.js';
 import { intoRegisterOutput } from '../api/output.js';
 import type { RegisterInput } from '../api/input.js';
 import { intoRegisterInput } from '../api/input.js';
-import { onCompositorEvent } from '../event.js';
+import { parseEvent } from '../event.js';
 import { intoRegisterImage, intoRegisterWebRenderer } from '../api/renderer.js';
+import { handleEvent } from './event.js';
+import type { ReactElement } from 'react';
 
 export class LiveCompositor {
   private manager: CompositorManager;
   private api: ApiClient;
-  private store: _liveCompositorInternals.LiveInstanceContextStore;
+  private store: _liveCompositorInternals.LiveInputStreamStore<string>;
   private outputs: Record<string, Output> = {};
   private startTime?: number;
 
   public constructor(manager: CompositorManager) {
     this.manager = manager;
     this.api = new ApiClient(this.manager);
-    this.store = new _liveCompositorInternals.LiveInstanceContextStore();
+    this.store = new _liveCompositorInternals.LiveInputStreamStore();
   }
 
   public async init(): Promise<void> {
-    this.manager.registerEventListener((event: unknown) => onCompositorEvent(this.store, event));
+    this.manager.registerEventListener((event: unknown) => this.handleEvent(event));
     await this.manager.setupInstance({ aheadOfTimeProcessing: false });
   }
 
-  public async registerOutput(outputId: string, request: RegisterOutput): Promise<object> {
-    const output = new Output(outputId, request, this.api, this.store, this.startTime);
+  public async registerOutput(
+    outputId: string,
+    root: ReactElement,
+    request: RegisterOutput
+  ): Promise<object> {
+    const output = new Output(outputId, root, request, this.api, this.store, this.startTime);
 
     const apiRequest = intoRegisterOutput(request, output.scene());
     const result = await this.api.registerOutput(outputId, apiRequest);
@@ -47,15 +53,24 @@ export class LiveCompositor {
 
   public async registerInput(inputId: string, request: RegisterInput): Promise<object> {
     return this.store.runBlocking(async updateStore => {
-      const result = await this.api.registerInput(inputId, intoRegisterInput(request));
-      updateStore({ type: 'add_input', input: { inputId } });
+      const inputRef = { type: 'global', id: inputId } as const;
+      const result = await this.api.registerInput(inputRef, intoRegisterInput(request));
+      updateStore({
+        type: 'add_input',
+        input: {
+          inputId,
+          videoDurationMs: result.video_duration_ms,
+          audioDurationMs: result.audio_duration_ms,
+        },
+      });
       return result;
     });
   }
 
   public async unregisterInput(inputId: string): Promise<object> {
     return this.store.runBlocking(async updateStore => {
-      const result = this.api.unregisterInput(inputId);
+      const inputRef = { type: 'global', id: inputId } as const;
+      const result = this.api.unregisterInput(inputRef, {});
       updateStore({ type: 'remove_input', inputId });
       return result;
     });
@@ -98,5 +113,13 @@ export class LiveCompositor {
       output.initClock(startTime);
     });
     this.startTime = startTime;
+  }
+
+  private handleEvent(rawEvent: unknown) {
+    const event = parseEvent(rawEvent);
+    if (!event) {
+      return;
+    }
+    handleEvent(this.store, this.outputs, event);
   }
 }

--- a/ts/@live-compositor/core/src/live/compositor.ts
+++ b/ts/@live-compositor/core/src/live/compositor.ts
@@ -13,14 +13,14 @@ import { intoRegisterImage, intoRegisterWebRenderer } from '../api/renderer.js';
 export class LiveCompositor {
   private manager: CompositorManager;
   private api: ApiClient;
-  private store: _liveCompositorInternals.InstanceContextStore;
+  private store: _liveCompositorInternals.LiveInstanceContextStore;
   private outputs: Record<string, Output> = {};
   private startTime?: number;
 
   public constructor(manager: CompositorManager) {
     this.manager = manager;
     this.api = new ApiClient(this.manager);
-    this.store = new _liveCompositorInternals.InstanceContextStore();
+    this.store = new _liveCompositorInternals.LiveInstanceContextStore();
   }
 
   public async init(): Promise<void> {

--- a/ts/@live-compositor/core/src/live/event.ts
+++ b/ts/@live-compositor/core/src/live/event.ts
@@ -1,0 +1,86 @@
+import type { _liveCompositorInternals } from 'live-compositor';
+import type { CompositorEvent } from '../event.js';
+import { CompositorEventType } from '../event.js';
+import type Output from './output.js';
+
+type LiveInputStreamStore<Id> = _liveCompositorInternals.LiveInputStreamStore<Id>;
+
+export function handleEvent(
+  store: LiveInputStreamStore<string>,
+  outputs: Record<string, Output>,
+  event: CompositorEvent
+) {
+  if (event.type === CompositorEventType.VIDEO_INPUT_DELIVERED) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'ready' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'ready' },
+      });
+    }
+  } else if (event.type === CompositorEventType.VIDEO_INPUT_PLAYING) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'playing' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'playing' },
+      });
+    }
+  } else if (event.type === CompositorEventType.VIDEO_INPUT_EOS) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'finished' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, videoState: 'finished' },
+      });
+    }
+  } else if (event.type === CompositorEventType.AUDIO_INPUT_DELIVERED) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'ready' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'ready' },
+      });
+    }
+  } else if (event.type === CompositorEventType.AUDIO_INPUT_PLAYING) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'playing' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'playing' },
+      });
+    }
+  } else if (event.type === CompositorEventType.AUDIO_INPUT_EOS) {
+    if (event.inputRef.type === 'global') {
+      store.dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'finished' },
+      });
+    } else if (event.inputRef.type === 'output-local') {
+      outputs[event.inputRef.outputId]?.inputStreamStore().dispatchUpdate({
+        type: 'update_input',
+        input: { inputId: event.inputRef.id, audioState: 'finished' },
+      });
+    }
+  }
+}

--- a/ts/@live-compositor/core/src/live/output.ts
+++ b/ts/@live-compositor/core/src/live/output.ts
@@ -10,7 +10,7 @@ import { throttle } from '../utils.js';
 
 type AudioContext = _liveCompositorInternals.AudioContext;
 type LiveTimeContext = _liveCompositorInternals.LiveTimeContext;
-type InstanceContextStore = _liveCompositorInternals.InstanceContextStore;
+type LiveInstanceContextStore = _liveCompositorInternals.LiveInstanceContextStore;
 
 class Output {
   api: ApiClient;
@@ -28,7 +28,7 @@ class Output {
     outputId: string,
     registerRequest: RegisterOutput,
     api: ApiClient,
-    store: InstanceContextStore,
+    store: LiveInstanceContextStore,
     startTimestamp: number | undefined
   ) {
     this.api = api;
@@ -130,7 +130,7 @@ function OutputRootComponent({
   outputShutdownStateStore,
 }: {
   outputRoot: React.ReactElement;
-  instanceStore: InstanceContextStore;
+  instanceStore: LiveInstanceContextStore;
   audioContext: AudioContext;
   timeContext: LiveTimeContext;
   outputShutdownStateStore: OutputShutdownStateStore;

--- a/ts/@live-compositor/core/src/offline/output.ts
+++ b/ts/@live-compositor/core/src/offline/output.ts
@@ -1,80 +1,94 @@
-import type { Outputs } from 'live-compositor';
-import { _liveCompositorInternals, View } from 'live-compositor';
-import type React from 'react';
-import { createElement, useSyncExternalStore } from 'react';
+import type { RegisterMp4Input } from 'live-compositor';
+import { _liveCompositorInternals } from 'live-compositor';
+import type { ReactElement } from 'react';
+import { createElement } from 'react';
 import type { ApiClient, Api } from '../api.js';
 import Renderer from '../renderer.js';
 import type { RegisterOutput } from '../api/output.js';
 import { intoAudioInputsConfiguration } from '../api/output.js';
 import { sleep } from '../utils.js';
+import { OFFLINE_OUTPUT_ID } from './compositor.js';
+import { OutputRootComponent, OutputShutdownStateStore } from '../rootComponent.js';
 
 type AudioContext = _liveCompositorInternals.AudioContext;
 type OfflineTimeContext = _liveCompositorInternals.OfflineTimeContext;
-type OfflineInstanceContextStore = _liveCompositorInternals.OfflineInstanceContextStore;
+type OfflineInputStreamStore<Id> = _liveCompositorInternals.OfflineInputStreamStore<Id>;
+type CompositorOutputContext = _liveCompositorInternals.CompositorOutputContext;
+type ChildrenLifetimeContext = _liveCompositorInternals.ChildrenLifetimeContext;
 
 class OfflineOutput {
   api: ApiClient;
   outputId: string;
   audioContext: AudioContext;
   timeContext: OfflineTimeContext;
+  childrenLifetimeContext: ChildrenLifetimeContext;
+  internalInputStreamStore: OfflineInputStreamStore<number>;
   outputShutdownStateStore: OutputShutdownStateStore;
-  durationMs: number;
+  durationMs?: number;
   updateTracker?: UpdateTracker;
 
-  videoRenderer?: Renderer;
-  initialAudioConfig?: Outputs.AudioInputsConfiguration;
+  supportsAudio: boolean;
+  supportsVideo: boolean;
+
+  renderer: Renderer;
 
   constructor(
-    outputId: string,
+    root: ReactElement,
     registerRequest: RegisterOutput,
     api: ApiClient,
-    store: OfflineInstanceContextStore,
-    durationMs: number
+    store: OfflineInputStreamStore<string>,
+    durationMs?: number
   ) {
     this.api = api;
-    this.outputId = outputId;
+    this.outputId = OFFLINE_OUTPUT_ID;
     this.outputShutdownStateStore = new OutputShutdownStateStore();
     this.durationMs = durationMs;
 
-    const supportsAudio = 'audio' in registerRequest && !!registerRequest.audio;
-    if (supportsAudio) {
-      this.initialAudioConfig = registerRequest.audio!.initial ?? { inputs: [] };
-    }
+    this.supportsAudio = 'audio' in registerRequest && !!registerRequest.audio;
+    this.supportsVideo = 'video' in registerRequest && !!registerRequest.video;
 
     const onUpdate = () => this.updateTracker?.onUpdate();
-    this.audioContext = new _liveCompositorInternals.AudioContext(onUpdate, supportsAudio);
-    this.timeContext = new _liveCompositorInternals.OfflineTimeContext(onUpdate, store);
+    this.audioContext = new _liveCompositorInternals.AudioContext(onUpdate);
+    this.internalInputStreamStore = new _liveCompositorInternals.OfflineInputStreamStore();
+    this.timeContext = new _liveCompositorInternals.OfflineTimeContext(
+      onUpdate,
+      (timestamp: number) => {
+        store.setCurrentTimestamp(timestamp);
+        this.internalInputStreamStore.setCurrentTimestamp(timestamp);
+      }
+    );
+    this.childrenLifetimeContext = new _liveCompositorInternals.ChildrenLifetimeContext(() => {});
 
-    if (registerRequest.video) {
-      const rootElement = createElement(OutputRootComponent, {
-        instanceStore: store,
-        audioContext: this.audioContext,
-        timeContext: this.timeContext,
-        outputRoot: registerRequest.video.root,
-        outputShutdownStateStore: this.outputShutdownStateStore,
-      });
+    const rootElement = createElement(OutputRootComponent, {
+      outputContext: new OutputContext(this, this.outputId, store),
+      outputRoot: root,
+      outputShutdownStateStore: this.outputShutdownStateStore,
+      childrenLifetimeContext: this.childrenLifetimeContext,
+    });
 
-      this.videoRenderer = new Renderer({
-        rootElement,
-        onUpdate,
-        idPrefix: `${outputId}-`,
-      });
-    }
+    this.renderer = new Renderer({
+      rootElement,
+      onUpdate,
+      idPrefix: `${this.outputId}-`,
+    });
   }
 
   public scene(): { video?: Api.Video; audio?: Api.Audio; schedule_time_ms: number } {
-    const audio = this.audioContext.getAudioConfig() ?? this.initialAudioConfig;
+    const audio = this.supportsAudio
+      ? intoAudioInputsConfiguration(this.audioContext.getAudioConfig())
+      : undefined;
+    const video = this.supportsVideo ? { root: this.renderer.scene() } : undefined;
     return {
-      video: this.videoRenderer && { root: this.videoRenderer.scene() },
-      audio: audio && intoAudioInputsConfiguration(audio),
+      video,
+      audio,
       schedule_time_ms: this.timeContext.timestampMs(),
     };
   }
 
   public async scheduleAllUpdates(): Promise<void> {
     this.updateTracker = new UpdateTracker();
-    while (this.timeContext.timestampMs() <= this.durationMs) {
-      console.log('Event loop', this.timeContext.timestampMs());
+
+    while (this.timeContext.timestampMs() <= (this.durationMs ?? Infinity)) {
       while (true) {
         await waitForBlockingTasks(this.timeContext);
         await this.updateTracker.waitForRenderEnd();
@@ -85,10 +99,89 @@ class OfflineOutput {
 
       const scene = this.scene();
       await this.api.updateScene(this.outputId, scene);
+
+      const timestampMs = this.timeContext.timestampMs();
+      if (this.childrenLifetimeContext.isDone() && this.durationMs === undefined) {
+        await this.api.unregisterOutput(OFFLINE_OUTPUT_ID, { schedule_time_ms: timestampMs });
+        break;
+      }
+
       this.timeContext.setNextTimestamp();
     }
-
     this.outputShutdownStateStore.close();
+  }
+}
+
+class OutputContext implements CompositorOutputContext {
+  public readonly globalInputStreamStore: _liveCompositorInternals.InputStreamStore<string>;
+  public readonly internalInputStreamStore: _liveCompositorInternals.InputStreamStore<number>;
+  public readonly audioContext: _liveCompositorInternals.AudioContext;
+  public readonly timeContext: _liveCompositorInternals.TimeContext;
+  public readonly outputId: string;
+  private output: OfflineOutput;
+
+  constructor(
+    output: OfflineOutput,
+    outputId: string,
+    store: _liveCompositorInternals.InputStreamStore<string>
+  ) {
+    this.output = output;
+    this.globalInputStreamStore = store;
+    this.internalInputStreamStore = output.internalInputStreamStore;
+    this.audioContext = output.audioContext;
+    this.timeContext = output.timeContext;
+    this.outputId = outputId;
+  }
+
+  public async registerMp4Input(
+    inputId: number,
+    registerRequest: RegisterMp4Input
+  ): Promise<{ videoDurationMs?: number; audioDurationMs?: number }> {
+    const inputRef = {
+      type: 'output-local',
+      outputId: this.outputId,
+      id: inputId,
+    } as const;
+    const offsetMs = this.timeContext.timestampMs();
+    const { video_duration_ms: videoDurationMs, audio_duration_ms: audioDurationMs } =
+      await this.output.api.registerInput(inputRef, {
+        type: 'mp4',
+        offset_ms: offsetMs,
+        ...registerRequest,
+      });
+    this.output.internalInputStreamStore.addInput({
+      inputId,
+      offsetMs,
+      videoDurationMs,
+      audioDurationMs,
+    });
+    if (registerRequest.offsetMs) {
+      this.timeContext.addTimestamp({ timestamp: offsetMs });
+    }
+    if (videoDurationMs) {
+      this.timeContext.addTimestamp({
+        timestamp: (registerRequest.offsetMs ?? 0) + videoDurationMs,
+      });
+    }
+    if (audioDurationMs) {
+      this.timeContext.addTimestamp({
+        timestamp: (registerRequest.offsetMs ?? 0) + audioDurationMs,
+      });
+    }
+    return {
+      videoDurationMs,
+      audioDurationMs,
+    };
+  }
+  public async unregisterMp4Input(inputId: number): Promise<void> {
+    await this.output.api.unregisterInput(
+      {
+        type: 'output-local',
+        outputId: this.outputId,
+        id: inputId,
+      },
+      { schedule_time_ms: this.timeContext.timestampMs() }
+    );
   }
 }
 
@@ -98,7 +191,7 @@ async function waitForBlockingTasks(offlineContext: OfflineTimeContext): Promise
   }
 }
 
-const MAX_NO_UPDATE_TIMEOUT_MS = 20;
+const MAX_NO_UPDATE_TIMEOUT_MS = 200;
 const MAX_RENDER_TIMEOUT_MS = 2000;
 
 /**
@@ -110,8 +203,8 @@ const MAX_RENDER_TIMEOUT_MS = 2000;
  * specific PTS then assume it's ready to grab a snapshot of a tree
  */
 class UpdateTracker {
-  private promise: Promise<void> = new Promise(() => { });
-  private promiseRes: () => void = () => { };
+  private promise: Promise<void> = new Promise(() => {});
+  private promiseRes: () => void = () => {};
   private updateTimeout: number = -1;
   private renderTimeout: number = -1;
 
@@ -144,66 +237,6 @@ class UpdateTracker {
     clearTimeout(this.renderTimeout);
     clearTimeout(this.updateTimeout);
   }
-}
-
-// External store to share shutdown information between React tree
-// and external code that is managing it.
-class OutputShutdownStateStore {
-  private shutdown: boolean = false;
-  private onChangeCallbacks: Set<() => void> = new Set();
-
-  public close() {
-    this.shutdown = true;
-    this.onChangeCallbacks.forEach(cb => cb());
-  }
-
-  // callback for useSyncExternalStore
-  public getSnapshot = (): boolean => {
-    return this.shutdown;
-  };
-
-  // callback for useSyncExternalStore
-  public subscribe = (onStoreChange: () => void): (() => void) => {
-    this.onChangeCallbacks.add(onStoreChange);
-    return () => {
-      this.onChangeCallbacks.delete(onStoreChange);
-    };
-  };
-}
-
-function OutputRootComponent({
-  outputRoot,
-  instanceStore,
-  timeContext,
-  audioContext,
-  outputShutdownStateStore,
-}: {
-  outputRoot: React.ReactElement;
-  instanceStore: InstanceContextStore;
-  timeContext: OfflineTimeContext;
-  audioContext: AudioContext;
-  outputShutdownStateStore: OutputShutdownStateStore;
-}) {
-  const shouldShutdown = useSyncExternalStore(
-    outputShutdownStateStore.subscribe,
-    outputShutdownStateStore.getSnapshot
-  );
-
-  if (shouldShutdown) {
-    // replace root with view to stop all the dynamic code
-    return createElement(View, {});
-  }
-
-  const reactCtx = {
-    instanceStore,
-    timeContext,
-    audioContext,
-  };
-  return createElement(
-    _liveCompositorInternals.LiveCompositorContext.Provider,
-    { value: reactCtx },
-    outputRoot
-  );
 }
 
 export default OfflineOutput;

--- a/ts/@live-compositor/core/src/rootComponent.ts
+++ b/ts/@live-compositor/core/src/rootComponent.ts
@@ -1,0 +1,85 @@
+import { _liveCompositorInternals, useAfterTimestamp, View } from 'live-compositor';
+import { createElement, useEffect, useSyncExternalStore, type ReactElement } from 'react';
+
+type CompositorOutputContext = _liveCompositorInternals.CompositorOutputContext;
+type ChildrenLifetimeContext = _liveCompositorInternals.ChildrenLifetimeContext;
+
+// External store to share shutdown information between React tree
+// and external code that is managing it.
+export class OutputShutdownStateStore {
+  private shutdown: boolean = false;
+  private onChangeCallbacks: Set<() => void> = new Set();
+
+  public close() {
+    this.shutdown = true;
+    this.onChangeCallbacks.forEach(cb => cb());
+  }
+
+  // callback for useSyncExternalStore
+  public getSnapshot = (): boolean => {
+    return this.shutdown;
+  };
+
+  // callback for useSyncExternalStore
+  public subscribe = (onStoreChange: () => void): (() => void) => {
+    this.onChangeCallbacks.add(onStoreChange);
+    return () => {
+      this.onChangeCallbacks.delete(onStoreChange);
+    };
+  };
+}
+
+const globalDelayRef = Symbol();
+
+export function OutputRootComponent({
+  outputContext,
+  outputRoot,
+  outputShutdownStateStore,
+  childrenLifetimeContext,
+}: {
+  outputContext: CompositorOutputContext;
+  outputRoot: ReactElement;
+  outputShutdownStateStore: OutputShutdownStateStore;
+  childrenLifetimeContext: ChildrenLifetimeContext;
+}) {
+  const shouldShutdown = useSyncExternalStore(
+    outputShutdownStateStore.subscribe,
+    outputShutdownStateStore.getSnapshot
+  );
+
+  useMinimalStreamDuration(childrenLifetimeContext);
+
+  if (shouldShutdown) {
+    // replace root with view to stop all the dynamic code
+    return createElement(View, {});
+  }
+
+  return createElement(
+    _liveCompositorInternals.LiveCompositorContext.Provider,
+    { value: outputContext },
+    createElement(
+      _liveCompositorInternals.ChildrenLifetimeContextType.Provider,
+      { value: childrenLifetimeContext },
+      outputRoot
+    )
+  );
+}
+
+/**
+ * Add minimal 1 second lifetime in case there are not live
+ * components inside the scene.
+ */
+function useMinimalStreamDuration(childrenLifetimeContext: ChildrenLifetimeContext) {
+  useEffect(() => {
+    childrenLifetimeContext.removeRef(globalDelayRef);
+    return () => {
+      childrenLifetimeContext.removeRef(globalDelayRef);
+    };
+  }, []);
+  const afterTimestamp = useAfterTimestamp(1000);
+  useEffect(() => {
+    if (afterTimestamp) {
+      childrenLifetimeContext.removeRef(globalDelayRef);
+    }
+  }, [afterTimestamp]);
+}

--- a/ts/@live-compositor/core/tsconfig.json
+++ b/ts/@live-compositor/core/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "esm"
-  }
+  },
+  "include": ["src"]
 }

--- a/ts/@live-compositor/web-wasm/src/compositor.ts
+++ b/ts/@live-compositor/web-wasm/src/compositor.ts
@@ -6,6 +6,7 @@ import { intoRegisterOutput } from './output/registerOutput';
 import type { RegisterInput } from './input/registerInput';
 import { intoRegisterInput } from './input/registerInput';
 import type { RegisterImage } from './renderers';
+import type { ReactElement } from 'react';
 
 export type LiveCompositorOptions = {
   framerate?: Framerate;
@@ -44,8 +45,12 @@ export default class LiveCompositor {
     await this.coreCompositor!.init();
   }
 
-  public async registerOutput(outputId: string, request: RegisterOutput): Promise<void> {
-    await this.coreCompositor!.registerOutput(outputId, intoRegisterOutput(request));
+  public async registerOutput(
+    outputId: string,
+    root: ReactElement,
+    request: RegisterOutput
+  ): Promise<void> {
+    await this.coreCompositor!.registerOutput(outputId, root, intoRegisterOutput(request));
   }
 
   public async unregisterOutput(outputId: string): Promise<void> {

--- a/ts/@live-compositor/web-wasm/src/eventSender.ts
+++ b/ts/@live-compositor/web-wasm/src/eventSender.ts
@@ -1,5 +1,7 @@
-import type { CompositorEvent } from 'live-compositor';
-import { CompositorEventType } from 'live-compositor';
+import { _liveCompositorInternals } from 'live-compositor';
+
+export const CompositorEventType = _liveCompositorInternals.CompositorEventType;
+export const inputRefIntoRawId = _liveCompositorInternals.inputRefIntoRawId;
 
 export class EventSender {
   private eventCallback?: (event: object) => void;
@@ -8,7 +10,7 @@ export class EventSender {
     this.eventCallback = eventCallback;
   }
 
-  public sendEvent(event: CompositorEvent) {
+  public sendEvent(event: WasmCompositorEvent) {
     if (!this.eventCallback) {
       console.warn(`Failed to send event: ${event}`);
       return;
@@ -18,7 +20,7 @@ export class EventSender {
   }
 }
 
-function toWebSocketMessage(event: CompositorEvent): WebSocketMessage {
+function toWebSocketMessage(event: WasmCompositorEvent): WebSocketMessage {
   if (event.type == CompositorEventType.OUTPUT_DONE) {
     return {
       type: event.type,
@@ -32,32 +34,33 @@ function toWebSocketMessage(event: CompositorEvent): WebSocketMessage {
   };
 }
 
+export type WasmCompositorEvent =
+  | {
+      type:
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_DELIVERED
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_DELIVERED
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_PLAYING
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_PLAYING
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_EOS
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_EOS;
+      inputId: string;
+    }
+  | {
+      type: _liveCompositorInternals.CompositorEventType.OUTPUT_DONE;
+      outputId: string;
+    };
 export type WebSocketMessage =
   | {
-      type: CompositorEventType.AUDIO_INPUT_DELIVERED;
+      type:
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_DELIVERED
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_DELIVERED
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_PLAYING
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_PLAYING
+        | _liveCompositorInternals.CompositorEventType.AUDIO_INPUT_EOS
+        | _liveCompositorInternals.CompositorEventType.VIDEO_INPUT_EOS;
       input_id: string;
     }
   | {
-      type: CompositorEventType.VIDEO_INPUT_DELIVERED;
-      input_id: string;
-    }
-  | {
-      type: CompositorEventType.AUDIO_INPUT_PLAYING;
-      input_id: string;
-    }
-  | {
-      type: CompositorEventType.VIDEO_INPUT_PLAYING;
-      input_id: string;
-    }
-  | {
-      type: CompositorEventType.AUDIO_INPUT_EOS;
-      input_id: string;
-    }
-  | {
-      type: CompositorEventType.VIDEO_INPUT_EOS;
-      input_id: string;
-    }
-  | {
-      type: CompositorEventType.OUTPUT_DONE;
+      type: _liveCompositorInternals.CompositorEventType.OUTPUT_DONE;
       output_id: string;
     };

--- a/ts/@live-compositor/web-wasm/src/input/input.ts
+++ b/ts/@live-compositor/web-wasm/src/input/input.ts
@@ -1,6 +1,5 @@
 import type { InputId } from '@live-compositor/browser-render';
-import { CompositorEventType } from 'live-compositor';
-import type { EventSender } from '../eventSender';
+import { CompositorEventType, type EventSender } from '../eventSender';
 import type InputSource from './source';
 import { Queue } from '@datastructures-js/queue';
 import { H264Decoder } from './decoder/h264Decoder';

--- a/ts/@live-compositor/web-wasm/src/output/registerOutput.ts
+++ b/ts/@live-compositor/web-wasm/src/output/registerOutput.ts
@@ -1,13 +1,11 @@
 import type { Resolution } from '@live-compositor/browser-render';
 import type { RegisterOutput as InternalRegisterOutput } from '@live-compositor/core';
-import type { ReactElement } from 'react';
 
 export type RegisterOutput = { type: 'canvas' } & RegisterCanvasOutput;
 
 export type RegisterCanvasOutput = {
   resolution: Resolution;
   canvas: HTMLCanvasElement;
-  root: ReactElement;
 };
 
 export function intoRegisterOutput(output: RegisterOutput): InternalRegisterOutput {
@@ -24,7 +22,6 @@ function fromRegisterCanvasOutput(output: RegisterCanvasOutput): InternalRegiste
     video: {
       resolution: output.resolution,
       canvas: output.canvas,
-      root: output.root,
     },
   };
 }

--- a/ts/create-live-compositor/templates/node-express-zustand/src/compositor.tsx
+++ b/ts/create-live-compositor/templates/node-express-zustand/src/compositor.tsx
@@ -10,7 +10,7 @@ export async function initializeCompositor() {
   // Display output with `ffplay`.
   await ffplayStartPlayerAsync('127.0.0.0', 8001);
 
-  await Compositor.registerOutput('output_1', {
+  await Compositor.registerOutput('output_1', <App />, {
     type: 'rtp_stream',
     port: 8001,
     ip: '127.0.0.1',
@@ -24,7 +24,6 @@ export async function initializeCompositor() {
         width: 1920,
         height: 1080,
       },
-      root: <App />,
     },
   });
 

--- a/ts/create-live-compositor/templates/node-minimal/src/index.tsx
+++ b/ts/create-live-compositor/templates/node-minimal/src/index.tsx
@@ -25,7 +25,7 @@ async function run() {
   // Display output with `ffplay`.
   await ffplayStartPlayerAsync('127.0.0.0', 8001);
 
-  await compositor.registerOutput('output_1', {
+  await compositor.registerOutput('output_1', <App />, {
     type: 'rtp_stream',
     port: 8001,
     ip: '127.0.0.1',
@@ -39,7 +39,6 @@ async function run() {
         width: 1920,
         height: 1080,
       },
-      root: <App />,
     },
   });
 

--- a/ts/examples/node-examples/src/audio.tsx
+++ b/ts/examples/node-examples/src/audio.tsx
@@ -56,7 +56,7 @@ async function run() {
 
   await sleep(2000);
 
-  await compositor.registerOutput('output_1', {
+  await compositor.registerOutput('output_1', <ExampleApp />, {
     type: 'rtp_stream',
     port: 8001,
     transportProtocol: 'tcp_server',
@@ -69,7 +69,6 @@ async function run() {
         width: 1920,
         height: 1080,
       },
-      root: <ExampleApp />,
     },
     audio: {
       encoder: {

--- a/ts/examples/node-examples/src/combine_mp4.tsx
+++ b/ts/examples/node-examples/src/combine_mp4.tsx
@@ -29,6 +29,7 @@ function ExampleApp() {
 
 function InputTile({ inputId }: { inputId: string }) {
   const currentTimestamp = useCurrentTimestamp();
+  console.log(currentTimestamp);
   const [mountTime, _setMountTime] = useState(() => currentTimestamp);
   const afterDelay = useAfterTimestamp(mountTime + 1000);
 

--- a/ts/examples/node-examples/src/combine_mp4.tsx
+++ b/ts/examples/node-examples/src/combine_mp4.tsx
@@ -29,7 +29,6 @@ function ExampleApp() {
 
 function InputTile({ inputId }: { inputId: string }) {
   const currentTimestamp = useCurrentTimestamp();
-  console.log(currentTimestamp);
   const [mountTime, _setMountTime] = useState(() => currentTimestamp);
   const afterDelay = useAfterTimestamp(mountTime + 1000);
 
@@ -69,6 +68,7 @@ async function run() {
   });
 
   await compositor.render(
+    <ExampleApp />,
     {
       type: 'mp4',
       serverPath: path.join(__dirname, '../.assets/combing_mp4_output.mp4'),
@@ -81,7 +81,6 @@ async function run() {
           width: 1920,
           height: 1080,
         },
-        root: <ExampleApp />,
       },
     },
     10000

--- a/ts/examples/node-examples/src/concat_mp4.tsx
+++ b/ts/examples/node-examples/src/concat_mp4.tsx
@@ -1,59 +1,94 @@
 import { OfflineCompositor } from '@live-compositor/node';
-import { View, Text, Rescaler, InputStream, SlideShow, Slide } from 'live-compositor';
+import { View, Text, Rescaler, SlideShow, Slide, Mp4, InputStream } from 'live-compositor';
 import { downloadAllAssets } from './utils';
 import path from 'path';
+import type { ReactElement } from 'react';
 
 function ExampleApp() {
+  return (
+    <SlideShow>
+      <Slide durationMs={3000}>
+        <TitleSlide text="First slide show" />
+      </Slide>
+      <Slide>
+        <ExampleScene />
+      </Slide>
+      <Slide durationMs={3000}>
+        <TitleSlide text="Second slide show" />
+      </Slide>
+      <Slide>
+        <ExampleScene />
+      </Slide>
+    </SlideShow>
+  );
+}
+
+function ExampleScene() {
   return (
     <View>
       <SlideShow>
         <Slide>
-          <Input inputId="input_1" />
+          <TitleSlide text="Part 1" />
         </Slide>
-        <Slide durationMs={3_000}>
-          <View>
-            <Text
-              style={{
-                fontSize: 40,
-                color: '#FF0000',
-                lineHeight: 50,
-                backgroundColor: '#FFFFFF88',
-              }}>
-              Input
-            </Text>
-          </View>
+        <Slide durationMs={3000}>
+          <SlideWithLabel label="BigBuckBunny sample video as <InputStream />">
+            <InputStream inputId="input_1" />
+          </SlideWithLabel>
         </Slide>
         <Slide>
-          <Input inputId="input_2" />
+          <TitleSlide text="Part 2" />
         </Slide>
-        <Slide durationMs={3_000}>
-          <View>
-            <Text
-              style={{
-                fontSize: 40,
-                color: '#FF0000',
-                lineHeight: 50,
-                backgroundColor: '#FFFFFF88',
-              }}>
-              Input
-            </Text>
-          </View>
+        <Slide>
+          <SlideWithLabel label="ForBiggerEscapes sample video as <Mp4 />">
+            <Mp4
+              source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"
+              volume={0.8}
+            />
+          </SlideWithLabel>
+        </Slide>
+        <Slide>
+          <TitleSlide text="Part 3" />
+        </Slide>
+        <Slide>
+          <SlideWithLabel label="ForBiggerBlazes sample video as <Mp4 />">
+            <Mp4
+              source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4"
+              volume={0.8}
+            />
+          </SlideWithLabel>
+        </Slide>
+        <Slide durationMs={3000}>
+          <TitleSlide text="The end" />
         </Slide>
       </SlideShow>
     </View>
   );
 }
 
-function Input({ inputId }: { inputId: string }) {
+function TitleSlide(props: { text: string }) {
+  return (
+    <Rescaler>
+      <Text
+        style={{
+          fontSize: 800,
+          color: '#FF0000',
+          lineHeight: 800,
+          backgroundColor: '#FFFFFF88',
+        }}>
+        {props.text}
+      </Text>
+    </Rescaler>
+  );
+}
+
+function SlideWithLabel({ label, children }: { label: string; children: ReactElement }) {
   return (
     <View>
-      <Rescaler>
-        <InputStream inputId={inputId} volume={1.0} />
-      </Rescaler>
+      <Rescaler>{children}</Rescaler>
       <View style={{ bottom: 10, left: 10, height: 50 }}>
         <Text
           style={{ fontSize: 40, color: '#FF0000', lineHeight: 50, backgroundColor: '#FFFFFF88' }}>
-          Input ID: {inputId}
+          {label}
         </Text>
       </View>
     </View>
@@ -67,43 +102,31 @@ async function run() {
 
   await compositor.registerInput('input_1', {
     type: 'mp4',
-    //serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
-    serverPath: '/home/wojtek/Downloads/sd.mp4',
+    serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
     offsetMs: 0,
     required: true,
   });
 
-  await compositor.registerInput('input_2', {
+  await compositor.render(<ExampleApp />, {
     type: 'mp4',
-    serverPath: '/home/wojtek/Downloads/sd_no_audio.mp4',
-    offsetMs: 10_000,
-    required: true,
-  });
-
-  await compositor.render(
-    {
-      type: 'mp4',
-      serverPath: path.join(__dirname, '../.assets/concat_mp4_output.mp4'),
-      video: {
-        encoder: {
-          type: 'ffmpeg_h264',
-          preset: 'ultrafast',
-        },
-        resolution: {
-          width: 1920,
-          height: 1080,
-        },
-        root: <ExampleApp />,
+    serverPath: path.join(__dirname, '../.assets/concat_mp4_output.mp4'),
+    video: {
+      encoder: {
+        type: 'ffmpeg_h264',
+        preset: 'ultrafast',
       },
-      audio: {
-        encoder: {
-          type: 'aac',
-          channels: 'stereo',
-        },
+      resolution: {
+        width: 1920,
+        height: 1080,
       },
     },
-    80000
-  );
+    audio: {
+      encoder: {
+        type: 'aac',
+        channels: 'stereo',
+      },
+    },
+  });
   process.exit(0);
 }
 void run();

--- a/ts/examples/node-examples/src/concat_mp4.tsx
+++ b/ts/examples/node-examples/src/concat_mp4.tsx
@@ -2,34 +2,53 @@ import { OfflineCompositor } from '@live-compositor/node';
 import { View, Text, Rescaler, InputStream, SlideShow, Slide } from 'live-compositor';
 import { downloadAllAssets } from './utils';
 import path from 'path';
-import { useTimeLimitedComponent } from '../../../live-compositor/cjs/context/childrenLifetimeContext';
 
 function ExampleApp() {
   return (
     <View>
       <SlideShow>
         <Slide>
-          <Input inputId="input_1" endTimestamp={3_000} />
-        </Slide>
-        <Slide>
-          <Input inputId="input_2" endTimestamp={6_000} />
+          <Input inputId="input_1" />
         </Slide>
         <Slide durationMs={3_000}>
-          <Input inputId="input_1" endTimestamp={10_000} />
+          <View>
+            <Text
+              style={{
+                fontSize: 40,
+                color: '#FF0000',
+                lineHeight: 50,
+                backgroundColor: '#FFFFFF88',
+              }}>
+              Input
+            </Text>
+          </View>
+        </Slide>
+        <Slide>
+          <Input inputId="input_2" />
+        </Slide>
+        <Slide durationMs={3_000}>
+          <View>
+            <Text
+              style={{
+                fontSize: 40,
+                color: '#FF0000',
+                lineHeight: 50,
+                backgroundColor: '#FFFFFF88',
+              }}>
+              Input
+            </Text>
+          </View>
         </Slide>
       </SlideShow>
     </View>
   );
 }
 
-function Input({ inputId, endTimestamp }: { inputId: string; endTimestamp: number }) {
-  // Temporary, useTimeLimitedComponent is an internal hook, InputStream component will rely
-  // on the mp4 length returned from the compositor
-  useTimeLimitedComponent(endTimestamp);
+function Input({ inputId }: { inputId: string }) {
   return (
     <View>
       <Rescaler>
-        <InputStream inputId={inputId} />
+        <InputStream inputId={inputId} volume={1.0} />
       </Rescaler>
       <View style={{ bottom: 10, left: 10, height: 50 }}>
         <Text
@@ -48,15 +67,16 @@ async function run() {
 
   await compositor.registerInput('input_1', {
     type: 'mp4',
-    serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
+    //serverPath: path.join(__dirname, '../.assets/BigBuckBunny.mp4'),
+    serverPath: '/home/wojtek/Downloads/sd.mp4',
     offsetMs: 0,
     required: true,
   });
 
   await compositor.registerInput('input_2', {
     type: 'mp4',
-    serverPath: path.join(__dirname, '../.assets/ElephantsDream.mp4'),
-    offsetMs: 5000,
+    serverPath: '/home/wojtek/Downloads/sd_no_audio.mp4',
+    offsetMs: 10_000,
     required: true,
   });
 
@@ -75,8 +95,14 @@ async function run() {
         },
         root: <ExampleApp />,
       },
+      audio: {
+        encoder: {
+          type: 'aac',
+          channels: 'stereo',
+        },
+      },
     },
-    10000
+    80000
   );
   process.exit(0);
 }

--- a/ts/examples/node-examples/src/dynamic-inputs.tsx
+++ b/ts/examples/node-examples/src/dynamic-inputs.tsx
@@ -50,7 +50,7 @@ async function run() {
   void ffplayStartPlayerAsync('127.0.0.1', 8001);
   await sleep(2000);
 
-  await compositor.registerOutput('output_1', {
+  await compositor.registerOutput('output_1', <ExampleApp />, {
     type: 'rtp_stream',
     port: 8001,
     ip: '127.0.0.1',
@@ -64,7 +64,6 @@ async function run() {
         width: 1920,
         height: 1080,
       },
-      root: <ExampleApp />,
     },
   });
   await compositor.start();

--- a/ts/examples/node-examples/src/dynamic-outputs.tsx
+++ b/ts/examples/node-examples/src/dynamic-outputs.tsx
@@ -46,14 +46,13 @@ async function run() {
     preset: 'ultrafast',
   } as const;
 
-  await compositor.registerOutput('output_stream', {
+  await compositor.registerOutput('output_stream', <ExampleApp />, {
     type: 'rtp_stream',
     port: 8001,
     transportProtocol: 'tcp_server',
     video: {
       encoder: VIDEO_ENCODER_OPTS,
       resolution: RESOLUTION,
-      root: <ExampleApp />,
     },
     audio: {
       encoder: {
@@ -63,13 +62,12 @@ async function run() {
     },
   });
   void gstReceiveTcpStream('127.0.0.1', 8001);
-  await compositor.registerOutput('output_recording', {
+  await compositor.registerOutput('output_recording', <ExampleApp />, {
     type: 'mp4',
     serverPath: path.join(__dirname, '../.workingdir/dynamic_outputs_recording.mp4'),
     video: {
       encoder: VIDEO_ENCODER_OPTS,
       resolution: RESOLUTION,
-      root: <ExampleApp />,
     },
     audio: {
       encoder: {
@@ -94,13 +92,12 @@ async function run() {
     type: 'mp4',
     serverPath: path.join(__dirname, '../.assets/ElephantsDream.mp4'),
   });
-  await compositor.registerOutput('output_recording_part2', {
+  await compositor.registerOutput('output_recording_part2', <ExampleApp />, {
     type: 'mp4',
     serverPath: path.join(__dirname, '../.workingdir/dynamic_outputs_recording_10s.mp4'),
     video: {
       encoder: VIDEO_ENCODER_OPTS,
       resolution: RESOLUTION,
-      root: <ExampleApp />,
     },
     audio: {
       encoder: {

--- a/ts/examples/node-examples/src/dynamic-text.tsx
+++ b/ts/examples/node-examples/src/dynamic-text.tsx
@@ -58,7 +58,7 @@ async function run() {
   void ffplayStartPlayerAsync('127.0.0.1', 8001);
   await sleep(2000);
 
-  await compositor.registerOutput('output_1', {
+  await compositor.registerOutput('output_1', <ExampleApp />, {
     type: 'rtp_stream',
     port: 8001,
     ip: '127.0.0.1',
@@ -72,7 +72,6 @@ async function run() {
         width: 1920,
         height: 1080,
       },
-      root: <ExampleApp />,
     },
   });
 

--- a/ts/examples/node-examples/src/simple.tsx
+++ b/ts/examples/node-examples/src/simple.tsx
@@ -47,7 +47,7 @@ async function run() {
   void ffplayStartPlayerAsync('127.0.0.1', 8001);
   await sleep(2000);
 
-  await compositor.registerOutput('output_1', {
+  await compositor.registerOutput('output_1', <ExampleApp />, {
     type: 'rtp_stream',
     port: 8001,
     ip: '127.0.0.1',
@@ -61,7 +61,6 @@ async function run() {
         width: 1920,
         height: 1080,
       },
-      root: <ExampleApp />,
     },
   });
   await compositor.start();

--- a/ts/examples/vite-browser-render/src/examples/MP4Player.tsx
+++ b/ts/examples/vite-browser-render/src/examples/MP4Player.tsx
@@ -84,14 +84,13 @@ function useCompositor(): [LiveCompositor | undefined, (canvas: HTMLCanvasElemen
         'https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9a6Vc.ttf'
       );
       void compositor.registerInput('bunny_video', { type: 'mp4', url: BUNNY_URL });
-      await compositor.registerOutput('output', {
+      await compositor.registerOutput('output', <Scene />, {
         type: 'canvas',
         canvas: canvas,
         resolution: {
           width: 1280,
           height: 720,
         },
-        root: <Scene />,
       });
     };
 

--- a/ts/live-compositor/src/components/Mp4.ts
+++ b/ts/live-compositor/src/components/Mp4.ts
@@ -2,12 +2,12 @@ import { createElement, useContext } from 'react';
 import type * as Api from '../api.js';
 import type { SceneComponent } from '../component.js';
 import { createCompositorComponent } from '../component.js';
-import { useAudioInput, useInputStreams } from '../hooks.js';
+import { useAudioInput } from '../hooks.js';
 import { useTimeLimitedComponent } from '../context/childrenLifetimeContext.js';
 import { LiveCompositorContext } from '../context/index.js';
 import { OfflineTimeContext } from '../internal.js';
 
-export type InputStreamProps = {
+export type Mp4Props = {
   children?: undefined;
 
   /**
@@ -30,19 +30,18 @@ export type InputStreamProps = {
 
 type AudioPropNames = 'muted' | 'volume';
 
-const InnerInputStream =
-  createCompositorComponent<Omit<InputStreamProps, AudioPropNames>>(sceneBuilder);
+const InnerMp4 = createCompositorComponent<Omit<Mp4Props, AudioPropNames>>(sceneBuilder);
 
-function InputStream(props: InputStreamProps) {
+function Mp4(props: Mp4Props) {
   const { muted, volume, ...otherProps } = props;
   useAudioInput(props.inputId, {
     volume: muted ? 0 : (volume ?? 1),
   });
-  useInputStreamInOfflineContext(props.inputId);
-  return createElement(InnerInputStream, otherProps);
+  useMp4InOfflineContext(props.inputId);
+  return createElement(InnerMp4, otherProps);
 }
 
-function useInputStreamInOfflineContext(inputId: string) {
+function useMp4InOfflineContext(inputId: string) {
   const ctx = useContext(LiveCompositorContext);
   if (!(ctx.timeContext instanceof OfflineTimeContext)) {
     // condition is constant so it's fine to use hook after that
@@ -54,7 +53,7 @@ function useInputStreamInOfflineContext(inputId: string) {
   useTimeLimitedComponent((input?.offsetMs ?? 0) + (input?.audioDurationMs ?? 0));
 }
 
-function sceneBuilder(props: InputStreamProps, _children: SceneComponent[]): Api.Component {
+function sceneBuilder(props: Mp4Props, _children: SceneComponent[]): Api.Component {
   return {
     type: 'input_stream',
     id: props.id,
@@ -62,4 +61,4 @@ function sceneBuilder(props: InputStreamProps, _children: SceneComponent[]): Api
   };
 }
 
-export default InputStream;
+export default Mp4;

--- a/ts/live-compositor/src/components/SlideShow.ts
+++ b/ts/live-compositor/src/components/SlideShow.ts
@@ -7,6 +7,7 @@ import View from './View.js';
 import {
   ChildrenLifetimeContext,
   ChildrenLifetimeContextType,
+  useCompletableComponent,
   useTimeLimitedComponent,
 } from '../context/childrenLifetimeContext.js';
 
@@ -57,22 +58,25 @@ export function SlideShow(props: SlideShowProps) {
     prevChildrenRef.current = props.children;
   }, [props.children]);
 
-  const [slideEnd, setSlideEnd] = useState(false);
-  const onSlideEndChange = useCallback(() => {
-    setSlideEnd(true);
+  const [shouldCheckChildren, setShouldCheckChildren] = useState(false);
+  const onChildrenChange = useCallback(() => {
+    setShouldCheckChildren(true);
   }, []);
   const [slideContext, _setSlideCtx] = useState(
-    () => new ChildrenLifetimeContext(onSlideEndChange)
+    () => new ChildrenLifetimeContext(onChildrenChange)
   );
 
   useEffect(() => {
-    if (slideEnd) {
-      setSlideEnd(false);
+    if (shouldCheckChildren) {
+      setShouldCheckChildren(false);
       if (slideContext.isDone()) {
         setChildIndex(childIndex + 1);
       }
     }
-  }, [slideEnd]);
+  }, [shouldCheckChildren]);
+
+  // report this SlideShow lifetime to its parents (to support nested SlideShows)
+  useCompletableComponent(childIndex >= childrenArray.length);
 
   return createElement(
     ChildrenLifetimeContextType.Provider,

--- a/ts/live-compositor/src/context/childrenLifetimeContext.ts
+++ b/ts/live-compositor/src/context/childrenLifetimeContext.ts
@@ -23,6 +23,11 @@ export class ChildrenLifetimeContext {
   }
 }
 
+/**
+ * Context that exposes API to children to register themself as playing/in-progress. Some components
+ * will change their behavior based on the state of its in-direct children, e.g. Slides component will
+ * not switch Slide until children are finished.
+ */
 export const ChildrenLifetimeContextType = createContext(new ChildrenLifetimeContext(() => {}));
 
 /**
@@ -46,5 +51,5 @@ export function useTimeLimitedComponent(timestamp: number) {
     if (timestampObject && afterTimestamp) {
       childrenLifetimeContext.removeEndTimestamp(timestampObject);
     }
-  }, [afterTimestamp]);
+  }, [afterTimestamp, timestampObject]);
 }

--- a/ts/live-compositor/src/context/index.ts
+++ b/ts/live-compositor/src/context/index.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
-import { InstanceContextStore } from './instanceContextStore.js';
+import type { InstanceContextStore } from './instanceContextStore.js';
+import { LiveInstanceContextStore } from './instanceContextStore.js';
 import { AudioContext } from './audioOutputContext.js';
 import type { TimeContext } from './timeContext.js';
 import { LiveTimeContext } from './timeContext.js';
@@ -14,7 +15,7 @@ export type CompositorOutputContext = {
 };
 
 export const LiveCompositorContext = createContext<CompositorOutputContext>({
-  instanceStore: new InstanceContextStore(),
+  instanceStore: new LiveInstanceContextStore(),
   audioContext: new AudioContext(() => {}, false),
   timeContext: new LiveTimeContext(),
 });

--- a/ts/live-compositor/src/context/index.ts
+++ b/ts/live-compositor/src/context/index.ts
@@ -1,21 +1,37 @@
 import { createContext } from 'react';
-import type { InstanceContextStore } from './instanceContextStore.js';
-import { LiveInstanceContextStore } from './instanceContextStore.js';
 import { AudioContext } from './audioOutputContext.js';
 import type { TimeContext } from './timeContext.js';
 import { LiveTimeContext } from './timeContext.js';
+import { LiveInputStreamStore, type InputStreamStore } from './inputStreamStore.js';
+import type { RegisterMp4Input } from '../types/registerInput.js';
 
 export type CompositorOutputContext = {
-  // global store for the entire LiveCompositor instance
-  instanceStore: InstanceContextStore;
+  // global store for input stream state
+  globalInputStreamStore: InputStreamStore<string>;
+  // internal input streams store
+  internalInputStreamStore: InputStreamStore<number>;
   // Audio mixer configuration
   audioContext: AudioContext;
   // Time tracking and handling for blocking tasks
   timeContext: TimeContext;
+
+  outputId: string;
+
+  // TODO: aggregate that into some context object when we add more methods like this.
+  registerMp4Input: (
+    inputId: number,
+    registerRequest: RegisterMp4Input
+  ) => Promise<{ videoDurationMs?: number; audioDurationMs?: number }>;
+
+  unregisterMp4Input: (inputId: number) => Promise<void>;
 };
 
 export const LiveCompositorContext = createContext<CompositorOutputContext>({
-  instanceStore: new LiveInstanceContextStore(),
-  audioContext: new AudioContext(() => {}, false),
+  globalInputStreamStore: new LiveInputStreamStore(),
+  internalInputStreamStore: new LiveInputStreamStore(),
+  audioContext: new AudioContext(() => {}),
   timeContext: new LiveTimeContext(),
+  outputId: '',
+  registerMp4Input: async () => ({}),
+  unregisterMp4Input: async () => {},
 });

--- a/ts/live-compositor/src/context/instanceContextStore.ts
+++ b/ts/live-compositor/src/context/instanceContextStore.ts
@@ -6,6 +6,9 @@ export type InputStreamInfo = {
   inputId: string;
   videoState?: StreamState;
   audioState?: StreamState;
+  offsetMs?: number;
+  videoDurationMs?: number;
+  audioDurationMs?: number;
 };
 
 type UpdateAction =
@@ -17,7 +20,12 @@ type InstanceContext = {
   inputs: Record<Api.InputId, InputStreamInfo>;
 };
 
-export class InstanceContextStore {
+export interface InstanceContextStore {
+  getSnapshot: () => InstanceContext;
+  subscribe: (onStoreChange: () => void) => () => void;
+}
+
+export class LiveInstanceContextStore {
   private context: InstanceContext = {
     inputs: {},
   };
@@ -95,6 +103,69 @@ export class InstanceContextStore {
   private removeInput(inputId: string) {
     const inputs = { ...this.context.inputs };
     delete inputs[inputId];
+    this.context = { ...this.context, inputs };
+    this.signalUpdate();
+  }
+
+  private signalUpdate() {
+    for (const cb of this.onChangeCallbacks) {
+      cb();
+    }
+  }
+
+  // callback for useSyncExternalStore
+  public getSnapshot = (): InstanceContext => {
+    return this.context;
+  };
+
+  // callback for useSyncExternalStore
+  public subscribe = (onStoreChange: () => void): (() => void) => {
+    this.onChangeCallbacks.add(onStoreChange);
+    return () => {
+      this.onChangeCallbacks.delete(onStoreChange);
+    };
+  };
+}
+
+type OfflineAddInput = {
+  inputId: string;
+  offsetMs: number;
+  videoDurationMs?: number;
+  audioDurationMs?: number;
+};
+
+export class OfflineInstanceContextStore {
+  private context: InstanceContext = {
+    inputs: {},
+  };
+  private inputs: OfflineAddInput[] = [];
+  private onChangeCallbacks: Set<() => void> = new Set();
+
+  public addInput(update: OfflineAddInput) {
+    this.inputs.push(update);
+  }
+
+  // TimeContext should call that function. It will always trigger re-render, but there
+  // is no point to optimize it right now.
+  public setCurrentTimestamp(timestampMs: number) {
+    const inputs = Object.fromEntries(
+      this.inputs
+        .filter(input => timestampMs >= input.offsetMs)
+        .map(input => {
+          // TODO: We could add "unknown" state if Mp4 duration is not known
+          const inputState = {
+            inputId: input.inputId,
+            videoState:
+              input.offsetMs + (input.videoDurationMs ?? 0) <= timestampMs ? 'finished' : 'playing',
+            audioState:
+              input.offsetMs + (input.audioDurationMs ?? 0) <= timestampMs ? 'finished' : 'playing',
+            videoDurationMs: input.videoDurationMs,
+            audioDurationMs: input.audioDurationMs,
+            offsetMs: input.offsetMs,
+          } as const;
+          return [input.inputId, inputState];
+        })
+    );
     this.context = { ...this.context, inputs };
     this.signalUpdate();
   }

--- a/ts/live-compositor/src/context/internalStreamStore.ts
+++ b/ts/live-compositor/src/context/internalStreamStore.ts
@@ -1,0 +1,10 @@
+let nextStreamNumber = 1;
+
+/*
+ * Generates unique input stream id that can be used in e.g. Mp4 component
+ */
+export function newInternalStreamId(): number {
+  const result = nextStreamNumber;
+  nextStreamNumber += 1;
+  return result;
+}

--- a/ts/live-compositor/src/context/timeContext.ts
+++ b/ts/live-compositor/src/context/timeContext.ts
@@ -1,5 +1,3 @@
-import type { OfflineInstanceContextStore } from './instanceContextStore.js';
-
 export interface BlockingTask {
   done(): void;
 }
@@ -24,12 +22,12 @@ export class OfflineTimeContext {
   private currentTimestamp: number = 0;
   private onChangeCallbacks: Set<() => void> = new Set();
 
-  constructor(onChange: () => void, instanceStore: OfflineInstanceContextStore) {
+  constructor(onChange: () => void, onTimeChange: (timestam: number) => void) {
     this.onChange = onChange;
     this.tasks = [];
     this.timestamps = [];
     this.onChangeCallbacks.add(() => {
-      instanceStore.setCurrentTimestamp(this.currentTimestamp);
+      onTimeChange(this.currentTimestamp);
     });
   }
 

--- a/ts/live-compositor/src/context/timeContext.ts
+++ b/ts/live-compositor/src/context/timeContext.ts
@@ -1,3 +1,5 @@
+import type { OfflineInstanceContextStore } from './instanceContextStore.js';
+
 export interface BlockingTask {
   done(): void;
 }
@@ -22,10 +24,13 @@ export class OfflineTimeContext {
   private currentTimestamp: number = 0;
   private onChangeCallbacks: Set<() => void> = new Set();
 
-  constructor(onChange: () => void) {
+  constructor(onChange: () => void, instanceStore: OfflineInstanceContextStore) {
     this.onChange = onChange;
     this.tasks = [];
     this.timestamps = [];
+    this.onChangeCallbacks.add(() => {
+      instanceStore.setCurrentTimestamp(this.currentTimestamp);
+    });
   }
 
   public timestampMs(): number {

--- a/ts/live-compositor/src/hooks.ts
+++ b/ts/live-compositor/src/hooks.ts
@@ -70,11 +70,7 @@ export function useAfterTimestamp(timestamp: number): boolean {
     };
   }, [timestamp]);
 
-  if (ctx.timeContext) {
-    return currentTimestamp >= timestamp;
-  } else {
-    return false;
-  }
+  return currentTimestamp >= timestamp;
 }
 
 /**

--- a/ts/live-compositor/src/hooks.ts
+++ b/ts/live-compositor/src/hooks.ts
@@ -3,17 +3,17 @@ import { useContext, useEffect, useState, useSyncExternalStore } from 'react';
 import type * as Api from './api.js';
 import type { CompositorOutputContext } from './context/index.js';
 import { LiveCompositorContext } from './context/index.js';
-import type { InputStreamInfo } from './context/instanceContextStore.js';
 import type { BlockingTask } from './context/timeContext.js';
 import { OfflineTimeContext } from './context/timeContext.js';
+import type { InputStreamInfo } from './context/inputStreamStore.js';
 
-export function useInputStreams(): Record<Api.InputId, InputStreamInfo> {
+export function useInputStreams(): Record<Api.InputId, InputStreamInfo<string>> {
   const ctx = useContext(LiveCompositorContext);
   const instanceCtx = useSyncExternalStore(
-    ctx.instanceStore.subscribe,
-    ctx.instanceStore.getSnapshot
+    ctx.globalInputStreamStore.subscribe,
+    ctx.globalInputStreamStore.getSnapshot
   );
-  return instanceCtx.inputs;
+  return instanceCtx;
 }
 
 export type AudioOptions = {
@@ -29,9 +29,9 @@ export function useAudioInput(inputId: Api.InputId, audioOptions: AudioOptions) 
 
   useEffect(() => {
     const options = { ...audioOptions };
-    ctx.audioContext.addInputAudioComponent(inputId, options);
+    ctx.audioContext.addInputAudioComponent({ type: 'global', id: inputId }, options);
     return () => {
-      ctx.audioContext.removeInputAudioComponent(inputId, options);
+      ctx.audioContext.removeInputAudioComponent({ type: 'global', id: inputId }, options);
     };
   }, [audioOptions]);
 }

--- a/ts/live-compositor/src/index.ts
+++ b/ts/live-compositor/src/index.ts
@@ -14,9 +14,9 @@ import {
   useBlockingTask,
   useCurrentTimestamp,
 } from './hooks.js';
-import { CompositorEvent, CompositorEventType } from './types/events.js';
 import Show, { ShowProps } from './components/Show.js';
 import { SlideShow, Slide, SlideProps, SlideShowProps } from './components/SlideShow.js';
+import Mp4, { Mp4Props } from './components/Mp4.js';
 
 export { RegisterRtpInput, RegisterMp4Input } from './types/registerInput.js';
 export {
@@ -54,9 +54,9 @@ export {
   SlideProps,
   SlideShow,
   SlideShowProps,
+  Mp4,
+  Mp4Props,
 };
-
-export { CompositorEvent, CompositorEventType };
 
 export { useInputStreams, useAudioInput, useBlockingTask, useAfterTimestamp, useCurrentTimestamp };
 

--- a/ts/live-compositor/src/internal.ts
+++ b/ts/live-compositor/src/internal.ts
@@ -1,11 +1,18 @@
 // Internal logic used by `@live-compositor/core`, do not use directly
 
-export { LiveCompositorContext } from './context/index.js';
+export { LiveCompositorContext, CompositorOutputContext } from './context/index.js';
 export { OfflineTimeContext, LiveTimeContext, TimeContext } from './context/timeContext.js';
+export { AudioConfig } from './context/audioOutputContext.js';
 export { AudioContext } from './context/audioOutputContext.js';
 export {
-  InstanceContextStore,
-  LiveInstanceContextStore,
-  OfflineInstanceContextStore,
-} from './context/instanceContextStore.js';
+  InputStreamStore,
+  LiveInputStreamStore,
+  OfflineInputStreamStore,
+} from './context/inputStreamStore.js';
 export { SceneBuilder, SceneComponent } from './component.js';
+export { CompositorEvent, CompositorEventType } from './types/events.js';
+export { InputRef, inputRefIntoRawId, parseInputRef } from './types/inputRef.js';
+export {
+  ChildrenLifetimeContext,
+  ChildrenLifetimeContextType,
+} from './context/childrenLifetimeContext.js';

--- a/ts/live-compositor/src/internal.ts
+++ b/ts/live-compositor/src/internal.ts
@@ -3,5 +3,9 @@
 export { LiveCompositorContext } from './context/index.js';
 export { OfflineTimeContext, LiveTimeContext, TimeContext } from './context/timeContext.js';
 export { AudioContext } from './context/audioOutputContext.js';
-export { InstanceContextStore } from './context/instanceContextStore.js';
+export {
+  InstanceContextStore,
+  LiveInstanceContextStore,
+  OfflineInstanceContextStore,
+} from './context/instanceContextStore.js';
 export { SceneBuilder, SceneComponent } from './component.js';

--- a/ts/live-compositor/src/types/events.ts
+++ b/ts/live-compositor/src/types/events.ts
@@ -1,3 +1,5 @@
+import type { InputRef } from './inputRef.js';
+
 export enum CompositorEventType {
   AUDIO_INPUT_DELIVERED = 'AUDIO_INPUT_DELIVERED',
   VIDEO_INPUT_DELIVERED = 'VIDEO_INPUT_DELIVERED',
@@ -9,10 +11,10 @@ export enum CompositorEventType {
 }
 
 export type CompositorEvent =
-  | { type: CompositorEventType.AUDIO_INPUT_DELIVERED; inputId: string }
-  | { type: CompositorEventType.VIDEO_INPUT_DELIVERED; inputId: string }
-  | { type: CompositorEventType.AUDIO_INPUT_PLAYING; inputId: string }
-  | { type: CompositorEventType.VIDEO_INPUT_PLAYING; inputId: string }
-  | { type: CompositorEventType.AUDIO_INPUT_EOS; inputId: string }
-  | { type: CompositorEventType.VIDEO_INPUT_EOS; inputId: string }
+  | { type: CompositorEventType.AUDIO_INPUT_DELIVERED; inputRef: InputRef }
+  | { type: CompositorEventType.VIDEO_INPUT_DELIVERED; inputRef: InputRef }
+  | { type: CompositorEventType.AUDIO_INPUT_PLAYING; inputRef: InputRef }
+  | { type: CompositorEventType.VIDEO_INPUT_PLAYING; inputRef: InputRef }
+  | { type: CompositorEventType.AUDIO_INPUT_EOS; inputRef: InputRef }
+  | { type: CompositorEventType.VIDEO_INPUT_EOS; inputRef: InputRef }
   | { type: CompositorEventType.OUTPUT_DONE; outputId: string };

--- a/ts/live-compositor/src/types/inputRef.ts
+++ b/ts/live-compositor/src/types/inputRef.ts
@@ -1,0 +1,55 @@
+/**
+ * Represents ID of an input, it can mean either:
+ * - Input registered with `registerInput` method.
+ * - Input that was registered internally by components like <Mp4 />.
+ */
+export type InputRef =
+  | {
+      // Maps to "global:{id}" in HTTP API
+      type: 'global';
+      id: string;
+    }
+  | {
+      // Maps to "output-local:{id}:{outputId}" in HTTP API
+      type: 'output-local';
+      outputId: string;
+      id: number;
+    };
+
+export function areInputRefsEqual(ref1: InputRef, ref2: InputRef): boolean {
+  const sameType = ref1.type === ref2.type;
+  const sameId = ref1.id === ref2.id;
+  if (ref1.type === 'output-local' && ref2.type === 'output-local') {
+    return sameId && sameType && ref1.outputId === ref2.outputId;
+  } else {
+    return sameId && sameType;
+  }
+}
+
+export function inputRefIntoRawId(inputRef: InputRef): string {
+  if (inputRef.type == 'global') {
+    return `global:${inputRef.id}`;
+  } else {
+    return `output-local:${inputRef.id}:${inputRef.outputId}`;
+  }
+}
+
+export function parseInputRef(rawId: string): InputRef {
+  const split = rawId.split(':');
+  if (split.length < 2) {
+    throw new Error(`Invalid input ID. (${rawId})`);
+  } else if (split[0] === 'global') {
+    return {
+      type: 'global',
+      id: split.slice(1).join(),
+    };
+  } else if (split[0] === 'output-local') {
+    return {
+      type: 'output-local',
+      id: Number(split[1]),
+      outputId: split.slice(2).join(),
+    };
+  } else {
+    throw new Error(`Unknown input type (${split[0]}).`);
+  }
+}

--- a/ts/live-compositor/src/types/registerOutput.ts
+++ b/ts/live-compositor/src/types/registerOutput.ts
@@ -1,4 +1,3 @@
-import type React from 'react';
 import type * as Api from '../api.js';
 
 export type RegisterRtpOutput = {
@@ -52,8 +51,6 @@ export type RtpVideoOptions = {
    * Video encoder options.
    */
   encoder: RtpVideoEncoderOptions;
-
-  root: React.ReactElement;
 };
 
 export type Mp4VideoOptions = {
@@ -69,8 +66,6 @@ export type Mp4VideoOptions = {
    * Video encoder options.
    */
   encoder: Mp4VideoEncoderOptions;
-
-  root: React.ReactElement;
 };
 
 export type OutputCanvasVideoOptions = {
@@ -82,7 +77,6 @@ export type OutputCanvasVideoOptions = {
    * HTMLCanvasElement
    */
   canvas: any;
-  root: React.ReactElement;
 };
 
 export type RtpVideoEncoderOptions = {
@@ -122,10 +116,6 @@ export type RtpAudioOptions = {
    * Audio encoder options.
    */
   encoder: RtpAudioEncoderOptions;
-  /**
-   * Initial audio mixer configuration for output.
-   */
-  initial?: AudioInputsConfiguration;
 };
 
 export interface Mp4AudioOptions {
@@ -141,10 +131,6 @@ export interface Mp4AudioOptions {
    * Audio encoder options.
    */
   encoder: Mp4AudioEncoderOptions;
-  /**
-   * Initial audio mixer configuration for output.
-   */
-  initial?: AudioInputsConfiguration;
 }
 
 export type RtpAudioEncoderOptions = {
@@ -186,15 +172,3 @@ export type OutputEndCondition =
        */
       allInputs: boolean;
     };
-
-export interface AudioInputsConfiguration {
-  inputs: InputAudio[];
-}
-
-export interface InputAudio {
-  inputId: Api.InputId;
-  /**
-   * (**default=`1.0`**) float in `[0, 1]` range representing input volume
-   */
-  volume?: number | null;
-}

--- a/ts/live-compositor/tsconfig.cjs.json
+++ b/ts/live-compositor/tsconfig.cjs.json
@@ -4,6 +4,6 @@
     "outDir": "cjs",
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2015"
+    "target": "es2019"
   }
 }

--- a/ts/live-compositor/tsconfig.json
+++ b/ts/live-compositor/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "esm"
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
- Add `<Mp4 />` component that does not require registration to be used
- Add support in offline processing for `useInputStreams` hook
  - it will return `playing` or `finished` based on mp4 duration, it will not work for other input streams)
- `useInputStreams` now returns video and audio duration if it is known (both live and offline)
- `useInputStreams` will not return info about input registered internally by MP4 component
- duration in `LiveCompositor.render` is not required in offline processing, output stream will end when  Mp4/InputStreams/SlideShows used in scene end
