### PR TITLE
[web-wasm] Fix incorrent chunk timestamps

### DIFF
--- a/ts/@live-compositor/web-wasm/src/input/mp4/demuxer.ts
+++ b/ts/@live-compositor/web-wasm/src/input/mp4/demuxer.ts
@@ -78,7 +78,7 @@ export class MP4Demuxer {
     assert(this.samplesCount !== undefined);
 
     for (const sample of samples) {
-      const pts = (sample.cts * 1_000) / sample.timescale;
+      const pts = (sample.cts * 1_000_000) / sample.timescale;
       if (this.ptsOffset === undefined) {
         this.ptsOffset = -pts;
       }
@@ -86,7 +86,7 @@ export class MP4Demuxer {
       const chunk = new EncodedVideoChunk({
         type: sample.is_sync ? 'key' : 'delta',
         timestamp: pts + this.ptsOffset,
-        duration: (sample.duration * 1_000) / sample.timescale,
+        duration: (sample.duration * 1_000_000) / sample.timescale,
         data: sample.data,
       });
 

--- a/ts/@live-compositor/web-wasm/src/input/producer/decodingFrameProducer.ts
+++ b/ts/@live-compositor/web-wasm/src/input/producer/decodingFrameProducer.ts
@@ -137,10 +137,10 @@ export default class DecodingFrameProducer implements InputFrameProducer {
     assert(framerate);
 
     const frameDuration = framerateToDurationMs(framerate);
-    const targetPts = framePts + frameDuration * MAX_BUFFERING_SIZE;
+    const targetPtsUs = (framePts + frameDuration * MAX_BUFFERING_SIZE) * 1000;
 
     let chunk = this.source.peekChunk();
-    while (chunk && chunk.timestamp <= targetPts) {
+    while (chunk && chunk.timestamp <= targetPtsUs) {
       this.decoder.decode(chunk);
       this.source.nextChunk();
       chunk = this.source.peekChunk();


### PR DESCRIPTION
According to the spec, chunks should use microseconds instead of milliseconds.

Tested on:
- http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4
- https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4
- https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4