### PR TITLE
Update to the new version of `h264_reader`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,8 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "h264-reader"
-version = "0.7.1-dev"
-source = "git+https://github.com/membraneframework-labs/h264-reader.git?branch=live-compositor#9292ad0ab24b75e07815f546f41cef24b30b09c9"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036a78b2620d92f0ec57690bc792b3bb87348632ee5225302ba2e66a48021c6c"
 dependencies = [
  "bitstream-io",
  "hex-slice",

--- a/vk-video/Cargo.toml
+++ b/vk-video/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["vulkan", "video", "wgpu", "decoding", "h264"]
 ash = "0.38.0"
 bytes = "1"
 derivative = "2.2.0"
-h264-reader = { git = "https://github.com/membraneframework-labs/h264-reader.git", branch = "live-compositor" }
+h264-reader = "0.8.0"
 memchr = "2.7.4"
 thiserror = "1.0.59"
 tracing = "0.1.40"

--- a/vk-video/src/vulkan_decoder.rs
+++ b/vk-video/src/vulkan_decoder.rs
@@ -58,21 +58,6 @@ pub enum VulkanDecoderError {
     #[error("Vulkan error: {0}")]
     VkError(#[from] vk::Result),
 
-    #[error("Cannot find enough memory of the right type on the deivce")]
-    NoMemory,
-
-    #[error("The decoder instruction is not supported: {0:?}")]
-    DecoderInstructionNotSupported(Box<DecoderInstruction>),
-
-    #[error("Setting the frame cropping flag in sps is not supported")]
-    FrameCroppingNotSupported,
-
-    #[error("Bitstreams that contain fields rather than frames are not supported")]
-    FieldsNotSupported,
-
-    #[error("Scaling lists are not supported")]
-    ScalingListsNotSupported,
-
     #[error("A NALU requiring a session received before a session was created (probably before receiving first SPS)")]
     NoSession,
 

--- a/vk-video/src/vulkan_decoder/session_resources/parameters.rs
+++ b/vk-video/src/vulkan_decoder/session_resources/parameters.rs
@@ -69,7 +69,7 @@ impl VideoSessionParametersManager {
         let key = sps.seq_parameter_set_id.id();
         match self.sps.entry(key) {
             std::collections::hash_map::Entry::Occupied(mut e) => {
-                e.insert(sps.try_into()?);
+                e.insert(sps.into());
 
                 self.parameters = VideoSessionParameters::new(
                     self.device.clone(),
@@ -80,7 +80,7 @@ impl VideoSessionParametersManager {
                 )?
             }
             std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(sps.try_into()?);
+                e.insert(sps.into());
 
                 self.parameters.add(&[self.sps[&key].sps], &[])?;
             }
@@ -93,7 +93,7 @@ impl VideoSessionParametersManager {
         let key = (pps.seq_parameter_set_id.id(), pps.pic_parameter_set_id.id());
         match self.pps.entry(key) {
             std::collections::hash_map::Entry::Occupied(mut e) => {
-                e.insert(pps.try_into()?);
+                e.insert(pps.into());
 
                 self.parameters = VideoSessionParameters::new(
                     self.device.clone(),
@@ -105,7 +105,7 @@ impl VideoSessionParametersManager {
             }
 
             std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(pps.try_into()?);
+                e.insert(pps.into());
 
                 self.parameters.add(&[], &[self.pps[&key].pps])?;
             }


### PR DESCRIPTION
The new version includes handling scaling lists, so this patch also handles them correctly in our decoder. Unfortunately I'm unable to find any h264 videos that use scaling lists, so this is untested, but I figure if it doesn't work somebody will sooner or later come to us with an issue.

This brings us one step closer to releasing vk-video, since this removes the last git-based dependency.

Closes #859